### PR TITLE
Open WebUI MCP chain 도구의 검색 후 상세조회 연결

### DIFF
--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -9,14 +9,11 @@ import type { LawApiClient } from "../lib/api-client.js"
 import type { ToolResponse, LooseToolResponse } from "../lib/types.js"
 import {
   findLaws,
-  stripNonLawKeywords as _unused1,
   NON_LAW_NAME_RE,
   scoreLawRelevance,
   type LawInfo,
 } from "../lib/law-search.js"
 import { routeQuery } from "../lib/query-router.js"
-// chains.ts 내부 헬퍼가 참조하던 NON_LAW_NAME_RE만 유지 (stripNonLawKeywords는 findLaws 내부에서 사용)
-void _unused1
 import { runScenario, detectScenario, formatSections, formatSuggestedActions } from "./scenarios/index.js"
 import type { ScenarioType, ScenarioContext } from "./scenarios/index.js"
 
@@ -148,6 +145,14 @@ function filterReliableLawResults(laws: LawInfo[], query: string): LawInfo[] {
     .filter(word => word.length > 0)
 
   return laws.filter(law => scoreLawRelevance(law.lawName, query, queryWords) > 5)
+}
+
+function selectLawTextSource(laws: LawInfo[], query: string): { reliableLaws: LawInfo[], textLaw?: LawInfo, lowConfidence: boolean } {
+  const reliableLaws = filterReliableLawResults(laws, query)
+  if (reliableLaws.length > 0) {
+    return { reliableLaws, textLaw: reliableLaws[0], lowConfidence: false }
+  }
+  return { reliableLaws, textLaw: laws[0], lowConfidence: laws.length > 0 }
 }
 
 async function retryPrecedentsIfNeeded(
@@ -586,16 +591,16 @@ export async function chainFullResearch(
       callTool(searchPrecedents, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
       callTool(searchInterpretations, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
     ])
-    const lawsResult = filterReliableLawResults(rawLawsResult, input.query)
+    const { reliableLaws: lawsResult, textLaw, lowConfidence } = selectLawTextSource(rawLawsResult, input.query)
     const finalPrecResult = await retryPrecedentsIfNeeded(apiClient, input, precResult, aiResult)
 
     parts.push(secOrSkip("AI 법령검색 결과", aiResult))
 
     // 법령 본문 (첫 번째 결과)
-    if (lawsResult.length > 0) {
-      const p = lawsResult[0]
-      const lawText = await callTool(getLawText, apiClient, { mst: p.mst, apiKey: input.apiKey })
-      parts.push(secOrSkip(`${p.lawName} 본문`, lawText))
+    if (textLaw) {
+      const lawText = await callTool(getLawText, apiClient, { mst: textLaw.mst, apiKey: input.apiKey })
+      const confidenceSuffix = lowConfidence ? " (관련도 낮음)" : ""
+      parts.push(secOrSkip(`${textLaw.lawName} 본문${confidenceSuffix}`, lawText))
     }
 
     parts.push(secOrSkip("관련 판례", finalPrecResult))

--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -38,6 +38,7 @@ import { getLawText } from "./law-text.js"
 import { searchTaxTribunalDecisions } from "./tax-tribunal-decisions.js"
 import { searchNlrcDecisions, searchPipcDecisions } from "./committee-decisions.js"
 import { fetchSearchDetailChain, fetchCombinedSearchDetailChain } from "./search-detail-chain.js"
+import { buildCompactLegalQueries } from "./compact-query-planner.js"
 
 // ========================================
 // Types
@@ -57,8 +58,6 @@ type ExpansionType = "annex_fee" | "annex_form" | "annex_table" | "precedent" | 
 // ========================================
 
 const PRECEDENT_RETRY_LIMIT = 5
-const LEGAL_ISSUE_SUFFIX_RE =
-  /([가-힣]{2,12})\s*(침해|훼손|보호|배상|책임|의무|권리|청구|반환|철회|취소|해제|해지|담보|계약|행위|위자료|처분|해고|징계|과태료|보증금|임금)/g
 
 async function callTool(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -142,92 +141,6 @@ function isSearchFailure(result: CallResult): boolean {
   return result.isError || /\[NOT_FOUND\]|\[FAILED\]|검색 결과가 없습니다|조회 실패/.test(result.text)
 }
 
-function uniqueNonEmpty(values: string[]): string[] {
-  const seen = new Set<string>()
-  const unique: string[] = []
-  for (const value of values) {
-    const normalized = value.trim().replace(/\s+/g, " ")
-    if (!normalized || seen.has(normalized)) continue
-    seen.add(normalized)
-    unique.push(normalized)
-  }
-  return unique
-}
-
-function extractRetrySuggestions(text: string): string[] {
-  const suggestions: string[] = []
-  for (const line of text.split("\n")) {
-    if (!line.includes("재시도 제안")) continue
-    const matches = line.matchAll(/"([^"]+)"/g)
-    for (const match of matches) {
-      suggestions.push(match[1])
-    }
-  }
-  return uniqueNonEmpty(suggestions)
-}
-
-function isUsefulPrecedentCandidate(candidate: string, originalQuery: string): boolean {
-  const normalized = candidate.trim().replace(/\s+/g, " ")
-  if (!normalized || normalized === originalQuery) return false
-  if (normalized.length < 2) return false
-
-  const tokens = normalized.split(/\s+/)
-  if (/^(관한|대한|위한|따른|해당|관련)\s/.test(normalized)) return false
-  if (/(의|에)$/.test(tokens[0])) return false
-  if (tokens.some(token => /(에서|에게|으로|로서|로써|부터|까지)$/.test(token))) return false
-  return true
-}
-
-function extractRouteQueryCandidates(query: string): string[] {
-  const candidates: string[] = []
-  const route = routeQuery(query)
-
-  const addParamCandidate = (value: unknown): void => {
-    if (typeof value === "string") candidates.push(value)
-  }
-
-  addParamCandidate(route.params.query)
-  addParamCandidate(route.params.lawName)
-  for (const step of route.pipeline || []) {
-    addParamCandidate(step.params.query)
-    addParamCandidate(step.params.lawName)
-  }
-
-  return uniqueNonEmpty(candidates)
-}
-
-function extractAiLawPrecedentCandidates(text: string): string[] {
-  const issueCandidates: string[] = []
-  const titleCandidates: string[] = []
-  const lawNameCandidates: string[] = []
-
-  for (const line of text.split("\n")) {
-    const titleMatch = line.match(/제\d+조(?:의\d+)?\s*\(([^)]+)\)/)
-    if (titleMatch) {
-      const title = titleMatch[1]
-        .replace(/등(?:의)?\s*(효과|제한|기준)?/g, "")
-        .replace(/의\s*(내용|효과|기준|범위)$/g, "")
-        .trim()
-      if (title) titleCandidates.push(title)
-    }
-
-    if (/^\s+/.test(line) && !titleMatch) {
-      const issueLine = line.replace(/「[^」]+」/g, " ")
-      const matches = issueLine.matchAll(LEGAL_ISSUE_SUFFIX_RE)
-      for (const match of matches) {
-        issueCandidates.push(match[0].trim().replace(/\s+/g, " "))
-      }
-    }
-
-    const trimmed = line.trim()
-    if (/^[가-힣\s]+(법|법률|시행령|시행규칙)$/.test(trimmed)) {
-      lawNameCandidates.push(trimmed)
-    }
-  }
-
-  return uniqueNonEmpty([...issueCandidates, ...titleCandidates, ...lawNameCandidates])
-}
-
 function filterReliableLawResults(laws: LawInfo[], query: string): LawInfo[] {
   const queryWords = query.replace(NON_LAW_NAME_RE, " ")
     .trim()
@@ -245,13 +158,14 @@ async function retryPrecedentsIfNeeded(
 ): Promise<CallResult> {
   if (!isSearchFailure(precedentResult)) return precedentResult
 
-  const candidates = uniqueNonEmpty([
-    ...extractAiLawPrecedentCandidates(aiLawResult?.text || ""),
-    ...extractRouteQueryCandidates(input.query),
-    ...extractRetrySuggestions(precedentResult.text),
-  ])
-    .filter(candidate => isUsefulPrecedentCandidate(candidate, input.query))
-    .slice(0, PRECEDENT_RETRY_LIMIT)
+  const route = routeQuery(input.query)
+  const candidates = buildCompactLegalQueries({
+    originalQuery: input.query,
+    aiLawText: aiLawResult?.text,
+    route,
+    failedSearchText: precedentResult.text,
+    max: PRECEDENT_RETRY_LIMIT,
+  }).map(candidate => candidate.query)
 
   if (candidates.length === 0) return precedentResult
 

--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -175,10 +175,6 @@ function isUsefulPrecedentCandidate(candidate: string, originalQuery: string): b
   if (/^(관한|대한|위한|따른|해당|관련)\s/.test(normalized)) return false
   if (/(의|에)$/.test(tokens[0])) return false
   if (tokens.some(token => /(에서|에게|으로|로서|로써|부터|까지)$/.test(token))) return false
-  if (/^(타인|타인의|해당|관련|위|아래|다음|일반|필요|경우|사항|정보|법률|법령|시행)$/.test(normalized)) return false
-  if (tokens.length <= 2 && tokens.every(token => /^(공원|풍경|사진|구석|사람|얼굴|허락|SNS)$/i.test(token))) {
-    return false
-  }
   return true
 }
 

--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -11,8 +11,10 @@ import {
   findLaws,
   stripNonLawKeywords as _unused1,
   NON_LAW_NAME_RE,
+  scoreLawRelevance,
   type LawInfo,
 } from "../lib/law-search.js"
+import { routeQuery } from "../lib/query-router.js"
 // chains.ts 내부 헬퍼가 참조하던 NON_LAW_NAME_RE만 유지 (stripNonLawKeywords는 findLaws 내부에서 사용)
 void _unused1
 import { runScenario, detectScenario, formatSections, formatSuggestedActions } from "./scenarios/index.js"
@@ -35,6 +37,7 @@ import { searchAiLaw } from "./life-law.js"
 import { getLawText } from "./law-text.js"
 import { searchTaxTribunalDecisions } from "./tax-tribunal-decisions.js"
 import { searchNlrcDecisions, searchPipcDecisions } from "./committee-decisions.js"
+import { fetchSearchDetailChain, fetchCombinedSearchDetailChain } from "./search-detail-chain.js"
 
 // ========================================
 // Types
@@ -52,6 +55,10 @@ type ExpansionType = "annex_fee" | "annex_form" | "annex_table" | "precedent" | 
 // ========================================
 // Helpers
 // ========================================
+
+const PRECEDENT_RETRY_LIMIT = 5
+const LEGAL_ISSUE_SUFFIX_RE =
+  /([가-힣]{2,12})\s*(침해|훼손|보호|배상|책임|의무|권리|청구|반환|철회|취소|해제|해지|담보|계약|행위|위자료|처분|해고|징계|과태료|보증금|임금)/g
 
 async function callTool(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -127,6 +134,152 @@ function noResult(query: string): ToolResponse {
   }
   return {
     content: [{ type: "text", text: lines.join("\n") }],
+    isError: true,
+  }
+}
+
+function isSearchFailure(result: CallResult): boolean {
+  return result.isError || /\[NOT_FOUND\]|\[FAILED\]|검색 결과가 없습니다|조회 실패/.test(result.text)
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const value of values) {
+    const normalized = value.trim().replace(/\s+/g, " ")
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    unique.push(normalized)
+  }
+  return unique
+}
+
+function extractRetrySuggestions(text: string): string[] {
+  const suggestions: string[] = []
+  for (const line of text.split("\n")) {
+    if (!line.includes("재시도 제안")) continue
+    const matches = line.matchAll(/"([^"]+)"/g)
+    for (const match of matches) {
+      suggestions.push(match[1])
+    }
+  }
+  return uniqueNonEmpty(suggestions)
+}
+
+function isUsefulPrecedentCandidate(candidate: string, originalQuery: string): boolean {
+  const normalized = candidate.trim().replace(/\s+/g, " ")
+  if (!normalized || normalized === originalQuery) return false
+  if (normalized.length < 2) return false
+
+  const tokens = normalized.split(/\s+/)
+  if (/^(관한|대한|위한|따른|해당|관련)\s/.test(normalized)) return false
+  if (/(의|에)$/.test(tokens[0])) return false
+  if (tokens.some(token => /(에서|에게|으로|로서|로써|부터|까지)$/.test(token))) return false
+  if (/^(타인|타인의|해당|관련|위|아래|다음|일반|필요|경우|사항|정보|법률|법령|시행)$/.test(normalized)) return false
+  if (tokens.length <= 2 && tokens.every(token => /^(공원|풍경|사진|구석|사람|얼굴|허락|SNS)$/i.test(token))) {
+    return false
+  }
+  return true
+}
+
+function extractRouteQueryCandidates(query: string): string[] {
+  const candidates: string[] = []
+  const route = routeQuery(query)
+
+  const addParamCandidate = (value: unknown): void => {
+    if (typeof value === "string") candidates.push(value)
+  }
+
+  addParamCandidate(route.params.query)
+  addParamCandidate(route.params.lawName)
+  for (const step of route.pipeline || []) {
+    addParamCandidate(step.params.query)
+    addParamCandidate(step.params.lawName)
+  }
+
+  return uniqueNonEmpty(candidates)
+}
+
+function extractAiLawPrecedentCandidates(text: string): string[] {
+  const issueCandidates: string[] = []
+  const titleCandidates: string[] = []
+  const lawNameCandidates: string[] = []
+
+  for (const line of text.split("\n")) {
+    const titleMatch = line.match(/제\d+조(?:의\d+)?\s*\(([^)]+)\)/)
+    if (titleMatch) {
+      const title = titleMatch[1]
+        .replace(/등(?:의)?\s*(효과|제한|기준)?/g, "")
+        .replace(/의\s*(내용|효과|기준|범위)$/g, "")
+        .trim()
+      if (title) titleCandidates.push(title)
+    }
+
+    if (/^\s+/.test(line) && !titleMatch) {
+      const issueLine = line.replace(/「[^」]+」/g, " ")
+      const matches = issueLine.matchAll(LEGAL_ISSUE_SUFFIX_RE)
+      for (const match of matches) {
+        issueCandidates.push(match[0].trim().replace(/\s+/g, " "))
+      }
+    }
+
+    const trimmed = line.trim()
+    if (/^[가-힣\s]+(법|법률|시행령|시행규칙)$/.test(trimmed)) {
+      lawNameCandidates.push(trimmed)
+    }
+  }
+
+  return uniqueNonEmpty([...issueCandidates, ...titleCandidates, ...lawNameCandidates])
+}
+
+function filterReliableLawResults(laws: LawInfo[], query: string): LawInfo[] {
+  const queryWords = query.replace(NON_LAW_NAME_RE, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(word => word.length > 0)
+
+  return laws.filter(law => scoreLawRelevance(law.lawName, query, queryWords) > 5)
+}
+
+async function retryPrecedentsIfNeeded(
+  apiClient: LawApiClient,
+  input: { query: string; apiKey?: string },
+  precedentResult: CallResult,
+  aiLawResult?: CallResult
+): Promise<CallResult> {
+  if (!isSearchFailure(precedentResult)) return precedentResult
+
+  const candidates = uniqueNonEmpty([
+    ...extractAiLawPrecedentCandidates(aiLawResult?.text || ""),
+    ...extractRouteQueryCandidates(input.query),
+    ...extractRetrySuggestions(precedentResult.text),
+  ])
+    .filter(candidate => isUsefulPrecedentCandidate(candidate, input.query))
+    .slice(0, PRECEDENT_RETRY_LIMIT)
+
+  if (candidates.length === 0) return precedentResult
+
+  for (const query of candidates) {
+    const retried = await callTool(searchPrecedents, apiClient, {
+      query,
+      display: 5,
+      apiKey: input.apiKey,
+    })
+    if (!isSearchFailure(retried) && retried.text.trim()) {
+      return {
+        text: `판례 1차 검색 실패 후 재검색어 "${query}"로 조회했습니다.\n\n${retried.text}`,
+        isError: false,
+      }
+    }
+  }
+
+  return {
+    text: [
+      precedentResult.text,
+      "",
+      `재검색 시도(최대 ${PRECEDENT_RETRY_LIMIT}회): ${candidates.map(query => `"${query}"`).join(", ")}`,
+      "모든 재검색에서 판례 검색 결과가 없습니다.",
+    ].join("\n"),
     isError: true,
   }
 }
@@ -244,6 +397,15 @@ export async function chainActionBasis(
     parts.push(secOrSkip("관련 판례", precR))
     parts.push(secOrSkip("행정심판례", appealR))
 
+    const [interpDetail, precDetail, appealDetail] = await Promise.all([
+      fetchSearchDetailChain(apiClient, "search_interpretations", interpR, { apiKey: input.apiKey }),
+      fetchSearchDetailChain(apiClient, "search_precedents", precR, { apiKey: input.apiKey }),
+      fetchSearchDetailChain(apiClient, "search_admin_appeals", appealR, { apiKey: input.apiKey }),
+    ])
+    if (interpDetail) parts.push(secOrSkip("법령 해석례 상세", interpDetail))
+    if (precDetail) parts.push(secOrSkip("관련 판례 상세", precDetail))
+    if (appealDetail) parts.push(secOrSkip("행정심판례 상세", appealDetail))
+
     // 키워드 확장
     const exp = detectExpansions(input.query)
     if (exp.includes("annex_fee") || exp.includes("annex_table")) {
@@ -304,6 +466,14 @@ export async function chainDisputePrep(
 
     parts.push(secOrSkip("대법원 판례", results[0]))
     parts.push(secOrSkip("행정심판례", results[1]))
+
+    const [precDetail, appealDetail] = await Promise.all([
+      fetchSearchDetailChain(apiClient, "search_precedents", results[0], { apiKey: input.apiKey }),
+      fetchSearchDetailChain(apiClient, "search_admin_appeals", results[1], { apiKey: input.apiKey }),
+    ])
+    if (precDetail) parts.push(secOrSkip("대법원 판례 상세", precDetail))
+    if (appealDetail) parts.push(secOrSkip("행정심판례 상세", appealDetail))
+
     if (results[2]) {
       const domainNames: Record<string, string> = {
         tax: "조세심판원 결정",
@@ -311,6 +481,17 @@ export async function chainDisputePrep(
         privacy: "개인정보위 결정",
       }
       parts.push(secOrSkip(domainNames[domain] || "전문 결정례", results[2]))
+
+      const domainSearchTools: Record<string, string> = {
+        tax: "search_tax_tribunal_decisions",
+        labor: "search_nlrc_decisions",
+        privacy: "search_pipc_decisions",
+      }
+      const domainSearchTool = domainSearchTools[domain]
+      if (domainSearchTool) {
+        const domainDetail = await fetchSearchDetailChain(apiClient, domainSearchTool, results[2], { apiKey: input.apiKey })
+        if (domainDetail) parts.push(secOrSkip(`${domainNames[domain] || "전문 결정례"} 상세`, domainDetail))
+      }
     }
 
     // 해석례 (키워드 확장)
@@ -318,6 +499,8 @@ export async function chainDisputePrep(
     if (exp.includes("interpretation")) {
       const interp = await callTool(searchInterpretations, apiClient, { query: input.query, display: 5, apiKey: input.apiKey })
       parts.push(secOrSkip("법령 해석례", interp))
+      const interpDetail = await fetchSearchDetailChain(apiClient, "search_interpretations", interp, { apiKey: input.apiKey })
+      if (interpDetail) parts.push(secOrSkip("법령 해석례 상세", interpDetail))
     }
 
     return wrapResult(parts.join("\n"))
@@ -487,12 +670,14 @@ export async function chainFullResearch(
       try { return await findLaws(apiClient, input.query, input.apiKey, 2) }
       catch { return [] }
     }
-    const [aiResult, lawsResult, precResult, interpResult] = await Promise.all([
+    const [aiResult, rawLawsResult, precResult, interpResult] = await Promise.all([
       callTool(searchAiLaw, apiClient, { query: input.query, display: 10, apiKey: input.apiKey }),
       safeFindLaws(),
       callTool(searchPrecedents, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
       callTool(searchInterpretations, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
     ])
+    const lawsResult = filterReliableLawResults(rawLawsResult, input.query)
+    const finalPrecResult = await retryPrecedentsIfNeeded(apiClient, input, precResult, aiResult)
 
     parts.push(secOrSkip("AI 법령검색 결과", aiResult))
 
@@ -503,8 +688,15 @@ export async function chainFullResearch(
       parts.push(secOrSkip(`${p.lawName} 본문`, lawText))
     }
 
-    parts.push(secOrSkip("관련 판례", precResult))
+    parts.push(secOrSkip("관련 판례", finalPrecResult))
     parts.push(secOrSkip("법령 해석례", interpResult))
+
+    const [precDetail, interpDetail] = await Promise.all([
+      fetchSearchDetailChain(apiClient, "search_precedents", finalPrecResult, { apiKey: input.apiKey }),
+      fetchSearchDetailChain(apiClient, "search_interpretations", interpResult, { apiKey: input.apiKey }),
+    ])
+    if (precDetail) parts.push(secOrSkip("관련 판례 상세", precDetail))
+    if (interpDetail) parts.push(secOrSkip("법령 해석례 상세", interpDetail))
 
     // 키워드 확장
     const exp = detectExpansions(input.query)
@@ -667,6 +859,16 @@ export async function chainDocumentReview(
     }
     if (precTexts.length > 0) {
       parts.push(sec("관련 판례", precTexts.join("\n\n")))
+    }
+
+    const precedentDetail = await fetchCombinedSearchDetailChain(
+      apiClient,
+      "search_precedents",
+      searchResults.slice(0, uniqueHints.length),
+      { apiKey: input.apiKey }
+    )
+    if (precedentDetail) {
+      parts.push(secOrSkip("관련 판례 상세", precedentDetail))
     }
 
     // 법령 결과 합산

--- a/src/tools/compact-query-planner.ts
+++ b/src/tools/compact-query-planner.ts
@@ -1,0 +1,181 @@
+export type CompactQuerySource =
+  | "ai_law_article_title"
+  | "ai_law_law_article_title"
+  | "search_retry_hint"
+  | "router"
+
+export interface CompactQueryCandidate {
+  query: string
+  source: CompactQuerySource
+  score: number
+  reason: string
+}
+
+interface RouteLike {
+  params?: Record<string, unknown>
+  pipeline?: Array<{ params?: Record<string, unknown> }>
+}
+
+export interface CompactQueryInput {
+  originalQuery: string
+  aiLawText?: string
+  route?: RouteLike
+  failedSearchText?: string
+  max?: number
+}
+
+function normalizeArticleTitle(title: string): string {
+  return title
+    .replace(/등(?:의)?\s*(효과|제한|기준|방법|절차)?$/g, "")
+    .replace(/의\s*(내용|효과|기준|범위)$/g, "")
+    .trim()
+}
+
+function normalizeCandidate(query: string): string {
+  return query
+    .replace(/[“”]/g, "\"")
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function isUsefulCandidate(candidate: string, originalQuery: string): boolean {
+  const normalized = normalizeCandidate(candidate)
+  if (!normalized || normalized === normalizeCandidate(originalQuery)) return false
+  if (normalized.length < 2 || normalized.length > 40) return false
+
+  const tokens = normalized.split(/\s+/)
+  if (/^(관한|대한|위한|따른|해당|관련)\s/.test(normalized)) return false
+  if (tokens.some(token => /(에서|에게|으로|로서|로써|부터|까지)$/.test(token))) return false
+
+  return true
+}
+
+function pushCandidate(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string,
+  query: string,
+  source: CompactQuerySource,
+  score: number,
+  reason: string
+): void {
+  const normalized = normalizeCandidate(query)
+  if (!isUsefulCandidate(normalized, originalQuery)) return
+  if (seen.has(normalized)) return
+  seen.add(normalized)
+  out.push({ query: normalized, source, score, reason })
+}
+
+function addAiLawArticleCandidates(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string,
+  aiLawText: string
+): void {
+  let currentLawName = ""
+
+  for (const line of aiLawText.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    if (/^[가-힣A-Za-z0-9\s·ㆍ]+(법|법률|시행령|시행규칙|규칙|규정|령)$/.test(trimmed)) {
+      currentLawName = trimmed
+      continue
+    }
+
+    const titleMatch = trimmed.match(/제\d+조(?:의\d+)?\s*\(([^)]+)\)/)
+    if (!titleMatch) continue
+
+    const title = normalizeArticleTitle(titleMatch[1])
+    if (!title) continue
+
+    pushCandidate(
+      out,
+      seen,
+      originalQuery,
+      title,
+      "ai_law_article_title",
+      100,
+      "AI 법령검색 조문 제목"
+    )
+
+    if (currentLawName) {
+      pushCandidate(
+        out,
+        seen,
+        originalQuery,
+        `${currentLawName} ${title}`,
+        "ai_law_law_article_title",
+        90,
+        "AI 법령검색 법령명 + 조문 제목"
+      )
+    }
+  }
+}
+
+function addRetrySuggestionCandidates(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string,
+  failedSearchText: string
+): void {
+  for (const line of failedSearchText.split("\n")) {
+    if (!line.includes("재시도 제안")) continue
+    for (const match of line.matchAll(/"([^"]+)"/g)) {
+      pushCandidate(
+        out,
+        seen,
+        originalQuery,
+        match[1],
+        "search_retry_hint",
+        80,
+        "검색 실패 응답의 재시도 제안"
+      )
+    }
+  }
+}
+
+function addRouteCandidates(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string,
+  route: RouteLike
+): void {
+  const addParamCandidate = (value: unknown): void => {
+    if (typeof value !== "string") return
+    pushCandidate(
+      out,
+      seen,
+      originalQuery,
+      value,
+      "router",
+      70,
+      "query-router 후보"
+    )
+  }
+
+  addParamCandidate(route.params?.query)
+  addParamCandidate(route.params?.lawName)
+  for (const step of route.pipeline || []) {
+    addParamCandidate(step.params?.query)
+    addParamCandidate(step.params?.lawName)
+  }
+}
+
+export function buildCompactLegalQueries(input: CompactQueryInput): CompactQueryCandidate[] {
+  const seen = new Set<string>()
+  const candidates: CompactQueryCandidate[] = []
+
+  if (input.aiLawText) {
+    addAiLawArticleCandidates(candidates, seen, input.originalQuery, input.aiLawText)
+  }
+  if (input.failedSearchText) {
+    addRetrySuggestionCandidates(candidates, seen, input.originalQuery, input.failedSearchText)
+  }
+  if (input.route) {
+    addRouteCandidates(candidates, seen, input.originalQuery, input.route)
+  }
+
+  return candidates.slice(0, input.max ?? 5)
+}

--- a/src/tools/search-detail-chain.ts
+++ b/src/tools/search-detail-chain.ts
@@ -1,0 +1,163 @@
+import type { LawApiClient } from "../lib/api-client.js"
+import { SEARCH_DETAIL_CHAINS } from "../lib/tool-chain-config.js"
+import type { LooseToolResponse } from "../lib/types.js"
+import { getPrecedentText } from "./precedents.js"
+import { getInterpretationText } from "./interpretations.js"
+import { getTaxTribunalDecisionText } from "./tax-tribunal-decisions.js"
+import { getCustomsInterpretationText } from "./customs-interpretations.js"
+import { getConstitutionalDecisionText } from "./constitutional-decisions.js"
+import { getAdminAppealText } from "./admin-appeals.js"
+import { getFtcDecisionText, getPipcDecisionText, getNlrcDecisionText } from "./committee-decisions.js"
+import { getEnglishLawText } from "./english-law.js"
+import { getAdminRule } from "./admin-rule.js"
+import { getOrdinance } from "./ordinance.js"
+
+export interface SearchDetailCallResult {
+  text: string
+  isError: boolean
+}
+
+export interface SearchDetailOptions {
+  apiKey?: string
+  limit?: number
+}
+
+type DetailHandler = (
+  apiClient: LawApiClient,
+  input: Record<string, unknown>
+) => Promise<LooseToolResponse>
+
+const DETAIL_HANDLERS: Record<string, DetailHandler> = {
+  get_precedent_text: getPrecedentText as DetailHandler,
+  get_interpretation_text: getInterpretationText as DetailHandler,
+  get_tax_tribunal_decision_text: getTaxTribunalDecisionText as DetailHandler,
+  get_customs_interpretation_text: getCustomsInterpretationText as DetailHandler,
+  get_constitutional_decision_text: getConstitutionalDecisionText as DetailHandler,
+  get_admin_appeal_text: getAdminAppealText as DetailHandler,
+  get_ftc_decision_text: getFtcDecisionText as DetailHandler,
+  get_pipc_decision_text: getPipcDecisionText as DetailHandler,
+  get_nlrc_decision_text: getNlrcDecisionText as DetailHandler,
+  get_english_law_text: getEnglishLawText as DetailHandler,
+  get_admin_rule: getAdminRule as DetailHandler,
+  get_ordinance: getOrdinance as DetailHandler,
+}
+
+const FULL_FALSE_DETAIL_TOOLS = new Set([
+  "get_precedent_text",
+  "get_constitutional_decision_text",
+  "get_admin_appeal_text",
+])
+
+function defaultLimit(searchTool: string): number {
+  return searchTool === "search_precedents" ? 2 : 1
+}
+
+function makeGlobalRegex(regex: RegExp): RegExp {
+  const flags = regex.flags.includes("g") ? regex.flags : `${regex.flags}g`
+  return new RegExp(regex.source, flags)
+}
+
+export function extractDetailIds(searchTool: string, output: string, limit?: number): string[] {
+  const chain = SEARCH_DETAIL_CHAINS[searchTool]
+  if (!chain || !output.trim()) return []
+
+  const max = limit ?? defaultLimit(searchTool)
+  const regex = makeGlobalRegex(chain.idRegex)
+  const seen = new Set<string>()
+  const ids: string[] = []
+
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(output)) !== null) {
+    const id = match[1]?.trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+    if (ids.length >= max) break
+  }
+
+  return ids
+}
+
+async function callDetailTool(
+  apiClient: LawApiClient,
+  searchTool: string,
+  id: string,
+  options: SearchDetailOptions
+): Promise<SearchDetailCallResult> {
+  const chain = SEARCH_DETAIL_CHAINS[searchTool]
+  const handler = chain ? DETAIL_HANDLERS[chain.detailTool] : undefined
+  if (!chain || !handler) {
+    return { text: `상세조회 도구를 찾을 수 없습니다: ${searchTool}`, isError: true }
+  }
+
+  const input: Record<string, unknown> = { [chain.detailParam]: id }
+  if (options.apiKey) input.apiKey = options.apiKey
+  if (FULL_FALSE_DETAIL_TOOLS.has(chain.detailTool)) input.full = false
+
+  try {
+    const result = await handler(apiClient, input)
+    return {
+      text: result.content?.map(item => item.text).join("\n") || "",
+      isError: !!result.isError,
+    }
+  } catch (error) {
+    return {
+      text: `오류: ${error instanceof Error ? error.message : String(error)}`,
+      isError: true,
+    }
+  }
+}
+
+function header(searchTool: string, count: number): string {
+  const chain = SEARCH_DETAIL_CHAINS[searchTool]
+  const fullSuffix = searchTool === "search_precedents" ? ", full=false" : ""
+  return `자동 상세조회: ${searchTool} -> ${chain.detailTool} (상위 ${count}건${fullSuffix})`
+}
+
+export async function fetchSearchDetailChain(
+  apiClient: LawApiClient,
+  searchTool: string,
+  searchResult: SearchDetailCallResult,
+  options: SearchDetailOptions = {}
+): Promise<SearchDetailCallResult | null> {
+  const chain = SEARCH_DETAIL_CHAINS[searchTool]
+  if (!chain || searchResult.isError) return null
+
+  const ids = extractDetailIds(searchTool, searchResult.text, options.limit)
+  if (ids.length === 0) return null
+
+  const blocks: string[] = [header(searchTool, ids.length)]
+  let failures = 0
+
+  for (const id of ids) {
+    const detail = await callDetailTool(apiClient, searchTool, id, options)
+    if (detail.isError) failures += 1
+    blocks.push(`[${id}]\n${detail.text || "상세조회 결과가 비어 있습니다."}`)
+  }
+
+  return {
+    text: blocks.join("\n\n"),
+    isError: failures === ids.length,
+  }
+}
+
+export async function fetchCombinedSearchDetailChain(
+  apiClient: LawApiClient,
+  searchTool: string,
+  searchResults: SearchDetailCallResult[],
+  options: SearchDetailOptions = {}
+): Promise<SearchDetailCallResult | null> {
+  const combined = searchResults
+    .filter(result => !result.isError && result.text.trim())
+    .map(result => result.text)
+    .join("\n")
+
+  if (!combined.trim()) return null
+
+  return fetchSearchDetailChain(
+    apiClient,
+    searchTool,
+    { text: combined, isError: false },
+    options
+  )
+}

--- a/src/tools/search-detail-chain.ts
+++ b/src/tools/search-detail-chain.ts
@@ -127,11 +127,16 @@ export async function fetchSearchDetailChain(
   if (ids.length === 0) return null
 
   const blocks: string[] = [header(searchTool, ids.length)]
-  let failures = 0
 
-  for (const id of ids) {
-    const detail = await callDetailTool(apiClient, searchTool, id, options)
-    if (detail.isError) failures += 1
+  const details = await Promise.all(
+    ids.map(async id => ({
+      id,
+      detail: await callDetailTool(apiClient, searchTool, id, options),
+    }))
+  )
+
+  const failures = details.filter(({ detail }) => detail.isError).length
+  for (const { id, detail } of details) {
     blocks.push(`[${id}]\n${detail.text || "상세조회 결과가 비어 있습니다."}`)
   }
 

--- a/test/test-chain-full-research-precedent-retry.cjs
+++ b/test/test-chain-full-research-precedent-retry.cjs
@@ -59,7 +59,7 @@ function privacyAiLawXml() {
     "<법령명>정보통신망 이용촉진 및 정보보호 등에 관한 법률</법령명>",
     "<법령종류명>법률</법령종류명>",
     "<조문번호>0044</조문번호>",
-    "<조문제목>정보통신망에서의 권리보호</조문제목>",
+    "<조문제목>사생활 침해</조문제목>",
     "<조문내용>이용자는 사생활 침해 또는 명예훼손 등 타인의 권리를 침해하는 정보를 정보통신망에 유통시켜서는 아니 된다.</조문내용>",
     "<시행일자>20251001</시행일자>",
     "</법령조문>",
@@ -78,9 +78,14 @@ function privacyAiLawXml() {
 function manyAiLawXml() {
   return [
     "<aiSearch>",
-    "<검색결과개수>4</검색결과개수>",
+    "<검색결과개수>6</검색결과개수>",
     "<page>1</page>",
-    "<법령조문><법령명>민법</법령명><조문제목>불법행위의 내용</조문제목><조문내용>손해배상 위자료 과실 책임 하자담보 청약철회 사생활 침해 명예훼손 개인정보</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "<법령조문><법령명>민법</법령명><조문번호>0750</조문번호><조문제목>불법행위의 내용</조문제목><조문내용>테스트</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "<법령조문><법령명>민법</법령명><조문번호>0398</조문번호><조문제목>배상액의 예정</조문제목><조문내용>테스트</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "<법령조문><법령명>민법</법령명><조문번호>0543</조문번호><조문제목>해지 해제</조문제목><조문내용>테스트</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "<법령조문><법령명>근로기준법</법령명><조문번호>0023</조문번호><조문제목>해고 등의 제한</조문제목><조문내용>테스트</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "<법령조문><법령명>전자상거래 등에서의 소비자보호에 관한 법률</법령명><조문번호>0017</조문번호><조문제목>청약철회등</조문제목><조문내용>테스트</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "<법령조문><법령명>질서위반행위규제법</법령명><조문번호>0016</조문번호><조문제목>사전통지 및 의견 제출</조문제목><조문내용>테스트</조문내용><시행일자>20260101</시행일자></법령조문>",
     "</aiSearch>",
   ].join("")
 }
@@ -114,6 +119,23 @@ function genericContractAiLawXml() {
     "<조문제목>청약철회등</조문제목>",
     "<조문내용>통신판매업자와 재화등의 구매에 관한 계약을 체결한 소비자는 기간 이내에 해당 계약에 관한 청약철회등을 할 수 있다.</조문내용>",
     "<시행일자>20260120</시행일자>",
+    "</법령조문>",
+    "</aiSearch>",
+  ].join("")
+}
+
+function extendedIssueAiLawXml() {
+  return [
+    "<aiSearch>",
+    "<검색결과개수>1</검색결과개수>",
+    "<page>1</page>",
+    "<법령조문>",
+    "<법령명>고용정책 기본법</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0007</조문번호>",
+    "<조문제목>취업기회의 균등한 보장</조문제목>",
+    "<조문내용>사업주는 모집과 채용에서 고용 차별이 발생하지 않도록 하여야 한다.</조문내용>",
+    "<시행일자>20260101</시행일자>",
     "</법령조문>",
     "</aiSearch>",
   ].join("")
@@ -225,6 +247,25 @@ async function testIgnoresGenericContractPhrase(chainFullResearch) {
   assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
 }
 
+async function testUsesAiLawArticleTitleCandidate(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "취업기회의 균등한 보장",
+    aiLawXml: extendedIssueAiLawXml(),
+  })
+
+  const result = await chainFullResearch(apiClient, {
+    query: "채용 과정에서 불합리한 대우를 받았습니다",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [
+    "채용 과정에서 불합리한 대우를 받았습니다",
+    "취업기회의 균등한 보장",
+  ])
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"취업기회의 균등한 보장\""), text)
+}
+
 async function testSkipsLowConfidenceLawText(chainFullResearch) {
   const apiClient = makeApiClient({
     succeedOnQuery: "청약철회",
@@ -282,6 +323,7 @@ async function main() {
   await testRetriesSuggestedKeywordAfterRawPrecedentFailure(chainFullResearch)
   await testIgnoresQuotedLawNameFragments(chainFullResearch)
   await testIgnoresGenericContractPhrase(chainFullResearch)
+  await testUsesAiLawArticleTitleCandidate(chainFullResearch)
   await testSkipsLowConfidenceLawText(chainFullResearch)
   await testKeepsExplicitLawText(chainFullResearch)
   await testLimitsPrecedentRetriesToFive(chainFullResearch)

--- a/test/test-chain-full-research-precedent-retry.cjs
+++ b/test/test-chain-full-research-precedent-retry.cjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+const QUERY = "중고거래 옷 구매자 단순 변심 환불 의무"
+const PHOTO_QUERY = "공원에서 풍경 사진을 찍어서 SNS에 올리려고 하는데 사진 구석에 모르는 사람 얼굴이 작게 찍혀 있었다면, 제가 그 사람에게 일일이 허락을 받아야 하나요?"
+
+function noLawXml() {
+  return "<LawSearch><totalCnt>0</totalCnt><page>1</page></LawSearch>"
+}
+
+function lawSearchXml(lawName, lawId = "001504", mst = "272861") {
+  return [
+    "<LawSearch>",
+    "<totalCnt>1</totalCnt>",
+    "<page>1</page>",
+    "<law>",
+    `<법령명한글>${lawName}</법령명한글>`,
+    `<법령ID>${lawId}</법령ID>`,
+    `<법령일련번호>${mst}</법령일련번호>`,
+    "<법령구분명>법률</법령구분명>",
+    "</law>",
+    "</LawSearch>",
+  ].join("")
+}
+
+function lawTextJson(lawName) {
+  return JSON.stringify({
+    법령: {
+      기본정보: {
+        법령명_한글: lawName,
+        공포일자: "20250101",
+        시행일자: "20250101",
+      },
+      조문: {
+        조문단위: [
+          {
+            조문여부: "조문",
+            조문번호: "1",
+            조문제목: "목적",
+            조문내용: `제1조(${lawName}) 테스트 조문`,
+          },
+        ],
+      },
+    },
+  })
+}
+
+function noAiLawXml() {
+  return "<aiSearch><검색결과개수>0</검색결과개수><page>1</page></aiSearch>"
+}
+
+function privacyAiLawXml() {
+  return [
+    "<aiSearch>",
+    "<검색결과개수>2</검색결과개수>",
+    "<page>1</page>",
+    "<법령조문>",
+    "<법령명>정보통신망 이용촉진 및 정보보호 등에 관한 법률</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0044</조문번호>",
+    "<조문제목>정보통신망에서의 권리보호</조문제목>",
+    "<조문내용>이용자는 사생활 침해 또는 명예훼손 등 타인의 권리를 침해하는 정보를 정보통신망에 유통시켜서는 아니 된다.</조문내용>",
+    "<시행일자>20251001</시행일자>",
+    "</법령조문>",
+    "<법령조문>",
+    "<법령명>민법</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0750</조문번호>",
+    "<조문제목>불법행위의 내용</조문제목>",
+    "<조문내용>고의 또는 과실로 인한 위법행위로 타인에게 손해를 가한 자는 그 손해를 배상할 책임이 있다.</조문내용>",
+    "<시행일자>20260101</시행일자>",
+    "</법령조문>",
+    "</aiSearch>",
+  ].join("")
+}
+
+function manyAiLawXml() {
+  return [
+    "<aiSearch>",
+    "<검색결과개수>4</검색결과개수>",
+    "<page>1</page>",
+    "<법령조문><법령명>민법</법령명><조문제목>불법행위의 내용</조문제목><조문내용>손해배상 위자료 과실 책임 하자담보 청약철회 사생활 침해 명예훼손 개인정보</조문내용><시행일자>20260101</시행일자></법령조문>",
+    "</aiSearch>",
+  ].join("")
+}
+
+function quotedLawNameAiLawXml() {
+  return [
+    "<aiSearch>",
+    "<검색결과개수>1</검색결과개수>",
+    "<page>1</page>",
+    "<법령조문>",
+    "<법령명>콘텐츠산업 진흥법</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0027</조문번호>",
+    "<조문제목>청약철회 등</조문제목>",
+    "<조문내용>콘텐츠제작자는 「전자상거래 등에서의 소비자보호에 관한 법률」에 따라 청약철회 및 계약의 해제가 불가능한 경우를 표시하여야 한다.</조문내용>",
+    "<시행일자>20251001</시행일자>",
+    "</법령조문>",
+    "</aiSearch>",
+  ].join("")
+}
+
+function genericContractAiLawXml() {
+  return [
+    "<aiSearch>",
+    "<검색결과개수>1</검색결과개수>",
+    "<page>1</page>",
+    "<법령조문>",
+    "<법령명>전자상거래 등에서의 소비자보호에 관한 법률</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0017</조문번호>",
+    "<조문제목>청약철회등</조문제목>",
+    "<조문내용>통신판매업자와 재화등의 구매에 관한 계약을 체결한 소비자는 기간 이내에 해당 계약에 관한 청약철회등을 할 수 있다.</조문내용>",
+    "<시행일자>20260120</시행일자>",
+    "</법령조문>",
+    "</aiSearch>",
+  ].join("")
+}
+
+function noInterpretationXml() {
+  return "<Expc><totalCnt>0</totalCnt><page>1</page></Expc>"
+}
+
+function noPrecedentXml() {
+  return "<PrecSearch><totalCnt>0</totalCnt><page>1</page></PrecSearch>"
+}
+
+function precedentXml() {
+  return [
+    "<PrecSearch>",
+    "<totalCnt>1</totalCnt>",
+    "<page>1</page>",
+    "<prec>",
+    "<판례일련번호>12345</판례일련번호>",
+    "<사건명>중고거래 물품대금 반환 사건</사건명>",
+    "<사건번호>2024가단12345</사건번호>",
+    "<법원명>서울중앙지방법원</법원명>",
+    "<선고일자>20240101</선고일자>",
+    "<판결유형>판결</판결유형>",
+    "<판례상세링크>https://example.test/prec/12345</판례상세링크>",
+    "</prec>",
+    "</PrecSearch>",
+  ].join("")
+}
+
+function makeApiClient({ succeedOnQuery, aiLawXml = noAiLawXml(), lawXml = noLawXml() }) {
+  const precedentQueries = []
+  const lawTextRequests = []
+  return {
+    precedentQueries,
+    lawTextRequests,
+    async searchLaw() {
+      return lawXml
+    },
+    async getLawText(request) {
+      lawTextRequests.push(request)
+      return lawTextJson("가축전염병 예방법")
+    },
+    async fetchApi(request) {
+      if (request.target === "aiSearch") return aiLawXml
+      if (request.target === "expc") return noInterpretationXml()
+      if (request.target === "prec") {
+        const query = String(request.extraParams?.query || "")
+        precedentQueries.push(query)
+        return query === succeedOnQuery ? precedentXml() : noPrecedentXml()
+      }
+      throw new Error(`unexpected target: ${request.target}`)
+    },
+  }
+}
+
+async function testUsesAiLawIssueBeforeRawFirstWord(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "사생활 침해",
+    aiLawXml: privacyAiLawXml(),
+  })
+
+  const result = await chainFullResearch(apiClient, { query: PHOTO_QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [PHOTO_QUERY, "사생활 침해"])
+  assert.ok(!apiClient.precedentQueries.includes("공원에서"), apiClient.precedentQueries.join(", "))
+  assert.ok(text.includes('재검색어 "사생활 침해"'), text)
+  assert.ok(text.includes("중고거래 물품대금 반환 사건"), text)
+}
+
+async function testRetriesSuggestedKeywordAfterRawPrecedentFailure(chainFullResearch) {
+  const apiClient = makeApiClient({ succeedOnQuery: "중고거래" })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "중고거래"])
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"중고거래\""), text)
+  assert.ok(text.includes("중고거래 물품대금 반환 사건"), text)
+}
+
+async function testIgnoresQuotedLawNameFragments(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "청약철회",
+    aiLawXml: quotedLawNameAiLawXml(),
+  })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
+  assert.ok(!apiClient.precedentQueries.includes("소비자보호"), apiClient.precedentQueries.join(", "))
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+}
+
+async function testIgnoresGenericContractPhrase(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "청약철회",
+    aiLawXml: genericContractAiLawXml(),
+  })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
+  assert.ok(!apiClient.precedentQueries.includes("관한 계약"), apiClient.precedentQueries.join(", "))
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+}
+
+async function testSkipsLowConfidenceLawText(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "청약철회",
+    aiLawXml: genericContractAiLawXml(),
+    lawXml: lawSearchXml("가축전염병 예방법"),
+  })
+
+  const result = await chainFullResearch(apiClient, {
+    query: "중고거래로 옷을 판매했는데, 구매자가 색깔 불만으로 환불을 요구할 경우 판매자의 법적 의무와 대응 방법",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.strictEqual(apiClient.lawTextRequests.length, 0)
+  assert.ok(!text.includes("가축전염병 예방법 본문"), text)
+}
+
+async function testKeepsExplicitLawText(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "__never__",
+    lawXml: lawSearchXml("민법", "001706", "267305"),
+  })
+
+  const result = await chainFullResearch(apiClient, {
+    query: "민법 제750조 불법행위 손해배상",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.strictEqual(apiClient.lawTextRequests.length, 1)
+  assert.ok(text.includes("▶ 민법 본문"), text)
+}
+
+async function testLimitsPrecedentRetriesToFive(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "__never__",
+    aiLawXml: manyAiLawXml(),
+  })
+
+  await chainFullResearch(apiClient, {
+    query: "가나다 라마바 사아자 차카타 파하 환불 의무",
+    apiKey: "test",
+  })
+
+  assert.strictEqual(
+    apiClient.precedentQueries.length,
+    6,
+    `expected raw precedent search plus five retries, got ${apiClient.precedentQueries.length}: ${apiClient.precedentQueries.join(", ")}`
+  )
+}
+
+async function main() {
+  const { chainFullResearch } = await import("../build/tools/chains.js")
+  await testUsesAiLawIssueBeforeRawFirstWord(chainFullResearch)
+  await testRetriesSuggestedKeywordAfterRawPrecedentFailure(chainFullResearch)
+  await testIgnoresQuotedLawNameFragments(chainFullResearch)
+  await testIgnoresGenericContractPhrase(chainFullResearch)
+  await testSkipsLowConfidenceLawText(chainFullResearch)
+  await testKeepsExplicitLawText(chainFullResearch)
+  await testLimitsPrecedentRetriesToFive(chainFullResearch)
+  console.log("chain_full_research precedent retry tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/test-chain-full-research-precedent-retry.cjs
+++ b/test/test-chain-full-research-precedent-retry.cjs
@@ -266,7 +266,7 @@ async function testUsesAiLawArticleTitleCandidate(chainFullResearch) {
   assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"취업기회의 균등한 보장\""), text)
 }
 
-async function testSkipsLowConfidenceLawText(chainFullResearch) {
+async function testUsesLowConfidenceLawTextFallback(chainFullResearch) {
   const apiClient = makeApiClient({
     succeedOnQuery: "청약철회",
     aiLawXml: genericContractAiLawXml(),
@@ -279,8 +279,8 @@ async function testSkipsLowConfidenceLawText(chainFullResearch) {
   })
   const text = result.content?.[0]?.text || ""
 
-  assert.strictEqual(apiClient.lawTextRequests.length, 0)
-  assert.ok(!text.includes("가축전염병 예방법 본문"), text)
+  assert.strictEqual(apiClient.lawTextRequests.length, 1)
+  assert.ok(text.includes("▶ 가축전염병 예방법 본문 (관련도 낮음)"), text)
 }
 
 async function testKeepsExplicitLawText(chainFullResearch) {
@@ -324,7 +324,7 @@ async function main() {
   await testIgnoresQuotedLawNameFragments(chainFullResearch)
   await testIgnoresGenericContractPhrase(chainFullResearch)
   await testUsesAiLawArticleTitleCandidate(chainFullResearch)
-  await testSkipsLowConfidenceLawText(chainFullResearch)
+  await testUsesLowConfidenceLawTextFallback(chainFullResearch)
   await testKeepsExplicitLawText(chainFullResearch)
   await testLimitsPrecedentRetriesToFive(chainFullResearch)
   console.log("chain_full_research precedent retry tests passed")

--- a/test/test-chain-search-detail-integration.cjs
+++ b/test/test-chain-search-detail-integration.cjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+function noLawXml() {
+  return "<LawSearch><totalCnt>0</totalCnt><page>1</page></LawSearch>"
+}
+
+function noAiLawXml() {
+  return "<aiSearch><검색결과개수>0</검색결과개수><page>1</page></aiSearch>"
+}
+
+function noInterpretationXml() {
+  return "<Expc><totalCnt>0</totalCnt><page>1</page></Expc>"
+}
+
+function precedentXml(ids) {
+  return [
+    "<PrecSearch>",
+    `<totalCnt>${ids.length}</totalCnt>`,
+    "<page>1</page>",
+    ...ids.map((id) => [
+      "<prec>",
+      `<판례일련번호>${id}</판례일련번호>`,
+      `<사건명>검색 판례 ${id}</사건명>`,
+      `<사건번호>2024다${id}</사건번호>`,
+      "<법원명>대법원</법원명>",
+      "<선고일자>20240101</선고일자>",
+      "<판결유형>판결</판결유형>",
+      `<판례상세링크>https://example.test/prec/${id}</판례상세링크>`,
+      "</prec>",
+    ].join("")),
+    "</PrecSearch>",
+  ].join("")
+}
+
+function precedentDetailJson(id) {
+  return JSON.stringify({
+    PrecService: {
+      사건명: `상세 판례 ${id}`,
+      사건번호: `2024다${id}`,
+      법원명: "대법원",
+      선고일자: "20240101",
+      사건종류명: "민사",
+      판결유형: "판결",
+      판시사항: `판시사항 ${id}`,
+      판결요지: `판결요지 ${id}`,
+      참조조문: "민법 제398조",
+      판례내용: `전문 ${id}`,
+    },
+  })
+}
+
+function makeApiClient() {
+  const precedentSearchQueries = []
+  const precedentDetailIds = []
+  return {
+    precedentSearchQueries,
+    precedentDetailIds,
+    async searchLaw() {
+      return noLawXml()
+    },
+    async fetchApi(request) {
+      if (request.target === "aiSearch") return noAiLawXml()
+      if (request.target === "expc") return noInterpretationXml()
+      if (request.target === "prec" && request.endpoint === "lawSearch.do") {
+        const query = String(request.extraParams?.query || "")
+        precedentSearchQueries.push(query)
+        if (query.includes("위약금 감액")) return precedentXml(["111", "222"])
+        if (query.includes("판례")) return precedentXml(["333"])
+        return precedentXml(["111", "222", "333"])
+      }
+      if (request.target === "prec" && request.endpoint === "lawService.do") {
+        const id = String(request.extraParams?.ID || "")
+        precedentDetailIds.push(id)
+        return precedentDetailJson(id)
+      }
+      throw new Error(`unexpected API request: ${JSON.stringify(request)}`)
+    },
+  }
+}
+
+async function testChainFullResearchFetchesTopTwoPrecedentDetails(chainFullResearch) {
+  const apiClient = makeApiClient()
+
+  const result = await chainFullResearch(apiClient, {
+    query: "청약철회 청구",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentDetailIds, ["111", "222"])
+  assert.ok(text.includes("▶ 관련 판례 상세"), text)
+  assert.ok(text.includes("자동 상세조회: search_precedents -> get_precedent_text (상위 2건, full=false)"), text)
+  assert.ok(text.includes("상세 판례 111"), text)
+  assert.ok(text.includes("상세 판례 222"), text)
+  assert.ok(!text.includes("상세 판례 333"), text)
+}
+
+async function testDocumentReviewFetchesTopTwoPrecedentDetailsTotal(chainDocumentReview) {
+  const apiClient = makeApiClient()
+
+  const result = await chainDocumentReview(apiClient, {
+    text: "제1조 환불은 어떠한 경우에도 불가하다. 제2조 위약금은 계약금액의 80%로 한다.",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentDetailIds, ["111", "222"])
+  assert.ok(text.includes("▶ 관련 판례 상세"), text)
+  assert.ok(text.includes("상세 판례 111"), text)
+  assert.ok(text.includes("상세 판례 222"), text)
+  assert.ok(!text.includes("상세 판례 333"), text)
+}
+
+async function main() {
+  const { chainFullResearch, chainDocumentReview } = await import("../build/tools/chains.js")
+  await testChainFullResearchFetchesTopTwoPrecedentDetails(chainFullResearch)
+  await testDocumentReviewFetchesTopTwoPrecedentDetailsTotal(chainDocumentReview)
+  console.log("chain search detail integration tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/test-compact-query-planner.cjs
+++ b/test/test-compact-query-planner.cjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+const AI_LAW_TEXT = [
+  "지능형 법령검색 결과 (법령조문, 2건):",
+  "",
+  "전자상거래 등에서의 소비자보호에 관한 법률",
+  "   제0017조 (청약철회등)",
+  "   소비자는 통신판매업자와 재화등의 구매에 관한 계약을 체결한 경우 청약철회등을 할 수 있다.",
+  "   시행: 2026.01.20 | 공정거래위원회",
+  "",
+  "고용정책 기본법",
+  "   제0007조 (취업기회의 균등한 보장)",
+  "   사업주는 모집과 채용에서 고용 차별이 발생하지 않도록 하여야 한다.",
+  "   시행: 2026.01.01 | 고용노동부",
+].join("\n")
+
+async function testUsesStructuredAiLawSignals() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "중고거래로 옷을 팔았는데 환불해달라고 합니다",
+    aiLawText: AI_LAW_TEXT,
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.ok(candidates.includes("청약철회"), candidates.join(", "))
+  assert.ok(candidates.includes("전자상거래 등에서의 소비자보호에 관한 법률 청약철회"), candidates.join(", "))
+  assert.ok(candidates.includes("취업기회의 균등한 보장"), candidates.join(", "))
+  assert.ok(candidates.includes("고용정책 기본법 취업기회의 균등한 보장"), candidates.join(", "))
+}
+
+async function testDoesNotExtractBodySuffixKeywords() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "채용 과정에서 불합리한 대우를 받았습니다",
+    aiLawText: AI_LAW_TEXT,
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.ok(!candidates.includes("고용 차별"), candidates.join(", "))
+}
+
+async function testUsesRetrySuggestionsAndRouterCandidates() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "청약철회 판례를 찾아줘",
+    route: {
+      params: { query: "청약철회" },
+      pipeline: [{ params: { query: "전자상거래 청약철회" } }],
+    },
+    failedSearchText: '재시도 제안: "중고거래" 또는 "중고거래 옷"',
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.deepStrictEqual(candidates.slice(0, 4), [
+    "중고거래",
+    "중고거래 옷",
+    "청약철회",
+    "전자상거래 청약철회",
+  ])
+}
+
+async function testFiltersWeakCandidates() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const longCandidate = "가".repeat(41)
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "원문 그대로",
+    failedSearchText: `재시도 제안: "원문 그대로" 또는 "공원에서" 또는 "관한 계약" 또는 "${longCandidate}" 또는 "청약철회"`,
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.deepStrictEqual(candidates, ["청약철회"])
+}
+
+async function main() {
+  await testUsesStructuredAiLawSignals()
+  await testDoesNotExtractBodySuffixKeywords()
+  await testUsesRetrySuggestionsAndRouterCandidates()
+  await testFiltersWeakCandidates()
+  console.log("compact query planner tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/test-search-detail-chain.cjs
+++ b/test/test-search-detail-chain.cjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+function precedentSearchText() {
+  return [
+    "판례 검색 결과 (총 3건, 1페이지):",
+    "",
+    "[111] 첫 번째 판례",
+    "  사건번호: 2024다111",
+    "",
+    "[222] 두 번째 판례",
+    "  사건번호: 2024다222",
+    "",
+    "[333] 세 번째 판례",
+    "  사건번호: 2024다333",
+    "",
+  ].join("\n")
+}
+
+function interpretationSearchText() {
+  return [
+    "해석례 검색 결과 (총 2건, 1페이지):",
+    "",
+    "[900] 첫 번째 해석례",
+    "  해석례번호: 24-001",
+    "",
+    "[901] 두 번째 해석례",
+    "  해석례번호: 24-002",
+    "",
+  ].join("\n")
+}
+
+function makeApiClient() {
+  const requests = []
+  return {
+    requests,
+    async fetchApi(request) {
+      requests.push(request)
+      const id = request.extraParams?.ID
+      if (request.endpoint !== "lawService.do") {
+        throw new Error(`unexpected endpoint: ${request.endpoint}`)
+      }
+      if (request.target === "prec") {
+        return JSON.stringify({
+          PrecService: {
+            사건명: `상세 판례 ${id}`,
+            사건번호: `2024다${id}`,
+            법원명: "대법원",
+            선고일자: "20240101",
+            판결유형: "판결",
+            판시사항: `판시사항 ${id}`,
+            판결요지: `판결요지 ${id}`,
+            참조조문: "민법 제580조",
+            판례내용: `전문 ${id}`,
+          },
+        })
+      }
+      if (request.target === "expc") {
+        return JSON.stringify({
+          ExpcService: {
+            안건명: `상세 해석례 ${id}`,
+            법령해석례일련번호: id,
+            해석일자: "20240101",
+            질의기관명: "질의기관",
+            해석기관명: "법제처",
+            질의요지: `질의요지 ${id}`,
+            회답: `회답 ${id}`,
+            이유: `이유 ${id}`,
+          },
+        })
+      }
+      throw new Error(`unexpected target: ${request.target}`)
+    },
+  }
+}
+
+async function testExtractsMultipleIds() {
+  const { extractDetailIds } = await import("../build/tools/search-detail-chain.js")
+
+  assert.deepStrictEqual(
+    extractDetailIds("search_precedents", precedentSearchText(), 2),
+    ["111", "222"]
+  )
+  assert.deepStrictEqual(
+    extractDetailIds("search_interpretations", interpretationSearchText(), 1),
+    ["900"]
+  )
+}
+
+async function testFetchesTopTwoPrecedentDetails() {
+  const { fetchSearchDetailChain } = await import("../build/tools/search-detail-chain.js")
+  const apiClient = makeApiClient()
+
+  const result = await fetchSearchDetailChain(
+    apiClient,
+    "search_precedents",
+    { text: precedentSearchText(), isError: false },
+    { apiKey: "test" }
+  )
+
+  assert.ok(result, "expected detail chain result")
+  assert.strictEqual(result.isError, false)
+  assert.deepStrictEqual(
+    apiClient.requests.map((request) => request.extraParams.ID),
+    ["111", "222"]
+  )
+  assert.ok(result.text.includes("자동 상세조회: search_precedents -> get_precedent_text (상위 2건, full=false)"), result.text)
+  assert.ok(result.text.includes("상세 판례 111"), result.text)
+  assert.ok(result.text.includes("상세 판례 222"), result.text)
+  assert.ok(!result.text.includes("상세 판례 333"), result.text)
+}
+
+async function testFetchesTopOneNonPrecedentDetail() {
+  const { fetchSearchDetailChain } = await import("../build/tools/search-detail-chain.js")
+  const apiClient = makeApiClient()
+
+  const result = await fetchSearchDetailChain(
+    apiClient,
+    "search_interpretations",
+    { text: interpretationSearchText(), isError: false },
+    { apiKey: "test" }
+  )
+
+  assert.ok(result, "expected interpretation detail result")
+  assert.deepStrictEqual(
+    apiClient.requests.map((request) => request.extraParams.ID),
+    ["900"]
+  )
+  assert.ok(result.text.includes("자동 상세조회: search_interpretations -> get_interpretation_text (상위 1건)"), result.text)
+  assert.ok(result.text.includes("상세 해석례 900"), result.text)
+  assert.ok(!result.text.includes("상세 해석례 901"), result.text)
+}
+
+async function testCombinedResultsUseTopTwoTotal() {
+  const { fetchCombinedSearchDetailChain } = await import("../build/tools/search-detail-chain.js")
+  const apiClient = makeApiClient()
+
+  const result = await fetchCombinedSearchDetailChain(
+    apiClient,
+    "search_precedents",
+    [
+      { text: "[111] 첫 번째 판례\n[222] 두 번째 판례", isError: false },
+      { text: "[333] 세 번째 판례", isError: false },
+    ],
+    { apiKey: "test" }
+  )
+
+  assert.ok(result, "expected combined precedent detail result")
+  assert.deepStrictEqual(
+    apiClient.requests.map((request) => request.extraParams.ID),
+    ["111", "222"]
+  )
+  assert.ok(result.text.includes("상세 판례 111"), result.text)
+  assert.ok(result.text.includes("상세 판례 222"), result.text)
+  assert.ok(!result.text.includes("상세 판례 333"), result.text)
+}
+
+async function main() {
+  await testExtractsMultipleIds()
+  await testFetchesTopTwoPrecedentDetails()
+  await testFetchesTopOneNonPrecedentDetail()
+  await testCombinedResultsUseTopTwoTotal()
+  console.log("search detail chain tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## 요약

이 PR은 Claude Code, Codex CLI 같은 Frontier 모델 CLI 인터페이스를 위한 변경이 아닙니다.

목적은 **local Ollama/llama 계열 서버 + Open WebUI 채팅 인터페이스에서 `korean-law-mcp`를 MCP provider로 연결해 사용할 때**, 체인 도구가 검색 결과에서 멈추지 않고 필요한 상세조회까지 이어가도록 누락된 동작을 보완하는 것입니다.

현재 CLI 자연어 실행 경로에는 이미 `search_*` 결과에서 ID를 추출해 `get_*` 상세조회로 이어가는 정책이 있습니다. 하지만 MCP chain 도구 경로에서는 같은 정책이 적용되지 않아, Open WebUI 채팅 환경에서는 판례/해석례 검색 결과 목록과 “다음에 `get_precedent_text(...)`를 호출하라”는 힌트만 반환되고 실제 판례 본문은 포함되지 않는 문제가 있었습니다.

이 PR은 그 차이를 줄이기 위해, 기존 upstream의 `SEARCH_DETAIL_CHAINS` 매핑을 MCP chain 도구에서도 재사용합니다. 또한 긴 자연어 질문에서 판례 검색이 실패했을 때, 임의 법률 키워드 사전을 확장하는 방식이 아니라 이미 검색/API/router 결과에 포함된 구조화 단서를 사용해 짧은 재검색 후보를 만듭니다.

## 왜 필요한가

Open WebUI의 MCP provider 기반 채팅 인터페이스에서는 사용자가 법률 질문을 던지면 local model이 MCP 도구를 호출하고, 그 도구 결과를 바탕으로 최종 답변을 작성합니다.

이 흐름에서 chain 도구가 판례 목록까지만 반환하면 다음 문제가 생깁니다.

- 판례 제목, 사건번호, 선고일만 보고는 실제 판결 취지나 법리를 알기 어렵습니다.
- local model은 Frontier CLI 모델보다 다단계 도구 호출을 안정적으로 이어가지 못할 수 있습니다.
- 검색 결과에 “다음: get_precedent_text(...)” 힌트가 있어도, 채팅 환경에서는 그 다음 도구 호출이 항상 보장되지 않습니다.
- 결국 최종 답변이 실제 판례 본문이 아니라 검색 목록 수준의 정보만 보고 작성될 수 있습니다.

따라서 MCP chain 도구 자체가 검색 후 필요한 상세조회까지 포함해 반환하는 것이 Open WebUI 채팅 환경에서는 더 안전하고 일관된 동작입니다.

## 변경 내용

### 1. MCP chain용 검색 → 상세조회 헬퍼 추가

`src/tools/search-detail-chain.ts`를 추가했습니다.

이 헬퍼는 다음 일을 합니다.

- `src/lib/tool-chain-config.ts`의 `SEARCH_DETAIL_CHAINS`를 재사용합니다.
- `search_*` 결과 텍스트에서 상세조회에 필요한 ID를 순서대로 추출합니다.
- 중복 ID를 제거합니다.
- 도구별 상세조회 개수를 제한합니다.
- 매핑된 `get_*` 상세조회 도구를 직접 호출합니다.
- 직접 `search_*` 도구의 기존 목록 검색 동작은 바꾸지 않습니다.

### 2. MCP chain 도구에 자동 상세조회 섹션 추가

다음 chain 도구 결과에 상세조회 섹션을 추가했습니다.

- `chain_full_research`
  - 판례 검색 결과가 있으면 `관련 판례 상세`를 추가합니다.
  - 해석례 검색 결과가 있으면 `법령 해석례 상세`를 추가합니다.

- `chain_action_basis`
  - 해석례, 판례, 행정심판례 검색 결과 뒤에 각각 상세조회 섹션을 추가합니다.

- `chain_dispute_prep`
  - 판례, 행정심판례, 도메인별 결정례 검색 결과 뒤에 상세조회 섹션을 추가합니다.

- `chain_document_review`
  - 문서 분석 결과에서 나온 여러 검색 힌트의 판례 검색 결과를 합산한 뒤, 전체 상위 판례 상세를 추가합니다.

### 3. compact query planner 기반 판례 재검색 보강

`src/tools/compact-query-planner.ts`를 추가했습니다.

`chain_full_research`에서 긴 자연어 질문으로 1차 판례 검색이 실패하면, 이 planner가 짧은 재검색 후보를 만듭니다.

후보 생성 원칙은 다음과 같습니다.

- `search_ai_law` 결과의 조문 제목을 우선 사용합니다.
  - 예: `제17조(청약철회등)` → `청약철회`
- 필요하면 `법령명 + 조문 제목` 조합도 후보로 사용합니다.
  - 예: `전자상거래 등에서의 소비자보호에 관한 법률 청약철회`
- `search_precedents` 실패 응답의 `재시도 제안`을 활용합니다.
- `query-router`가 명시적으로 줄인 `params.query` / `lawName` 후보도 활용합니다.
- 원문과 동일한 후보는 제거합니다.
- 너무 긴 후보는 제거합니다.
- 조사로 끝나는 후보는 제거합니다.
- `관한 ...`, `대한 ...`, `위한 ...` 같은 접속형 조각 후보는 제거합니다.
- 중복 후보는 제거합니다.
- 판례 재검색은 최대 5회로 제한합니다.

중요하게, 이 planner는 임의 법률 도메인 suffix dictionary를 사용하지 않습니다. 예를 들어 모든 법률 도메인의 `계약`, `과징금`, `허가`, `압류`, `손해배상` 같은 단어 목록을 계속 늘리는 방식이 아니라, 법제처 AI 검색 결과와 기존 router/search 응답이 이미 제공한 구조화 단서를 재사용합니다.

### 4. 낮은 신뢰도의 법령 본문 조회 방지

긴 자연어 질문에서 일반 법령명 검색이 우연히 무관한 법령을 반환하는 경우가 있었습니다. 그래서 `chain_full_research`에서 법령 본문을 자동으로 붙일 때는 `scoreLawRelevance` 기준으로 관련도가 낮은 결과를 제외합니다.

이 변경은 질문과 무관한 법령 본문이 최종 chain 출력에 섞이는 위험을 줄이기 위한 것입니다.

## 상세조회 정책

무제한으로 상세조회 API를 호출하지 않도록 의도적으로 작게 제한했습니다.

- `search_precedents` → `get_precedent_text`: 상위 2건
- 그 외 `SEARCH_DETAIL_CHAINS`에 등록된 검색 도메인: 상위 1건
- `get_precedent_text`, `get_admin_appeal_text`, `get_constitutional_decision_text`는 `full=false`로 호출합니다.

판례는 제목만으로 결론을 판단하기 어렵기 때문에 상위 2건을 가져오도록 했습니다. 반면 해석례나 결정례 등은 한 건만으로도 실질적인 판단 단서가 되는 경우가 많고, 응답 길이와 API 호출량을 줄이기 위해 기본값을 상위 1건으로 두었습니다.

## 원인 분석

기존 코드에는 이미 CLI용 검색 → 상세조회 정책이 있었습니다.

- `src/lib/tool-chain-config.ts`
  - `SEARCH_DETAIL_CHAINS` 매핑 정의
- `src/lib/cli-executor.ts`
  - 자연어 CLI 실행 후 검색 결과에서 ID를 추출하고 상세조회 파이프라인 실행

하지만 MCP chain 도구는 별도의 orchestrator로 동작합니다. `src/tools/chains.ts`는 여러 검색 도구를 호출하고 결과 텍스트를 조합하지만, CLI의 검색 → 상세조회 정책을 적용하지 않았습니다.

결과적으로 MCP client, 특히 Open WebUI 채팅 환경에서는 chain 도구가 “검색 목록 + 다음 도구 호출 힌트”에서 멈추는 경우가 있었습니다.

이 PR은 public tool schema를 바꾸지 않고, MCP chain 내부에서 기존 upstream 정책을 재사용해 이 누락된 연결을 채웁니다.

## A/B 테스트 결과

수동 검증에 사용한 질문은 다음과 같습니다.

```text
중고거래로 옷을 팔았는데, 구매자가 집에 가서 입어보더니 색깔이 생각보다 안 어울린다고 바로 환불해달래요. 이미 돈도 받았고 물건도 넘겼는데 제가 꼭 환불을 해줘야 하나요?
```

### 변경 전

관찰된 동작은 다음과 같았습니다.

- `chain_full_research`가 법령 검색 결과는 반환합니다.
- 긴 자연어 질문 그대로 판례 검색을 하면 결과가 없을 수 있습니다.
- 판례 검색이 성공해도 판례 목록만 반환합니다.
- 출력에는 `get_precedent_text(id="...")`를 호출하라는 힌트가 남지만, 실제 판례 본문은 포함되지 않습니다.
- 이전 테스트에서는 약한 검색어 때문에 접속형 조각 검색어가 사용되거나, 질문과 무관한 법령 본문이 붙는 경우도 있었습니다.

### 변경 후

동일 유형의 질문에서 다음을 확인했습니다.

```json
{
  "hasPrecedentDetail": true,
  "hasAutoDetail": true,
  "hasUnrelatedLawBody": false,
  "hasConnectorFragmentRetry": false,
  "hasUsefulRetryKeyword": true
}
```

변경 후 chain 출력에는 다음 내용이 포함됩니다.

- `관련 판례` 검색 결과
- 원문 자연어 판례 검색 실패 시 조문 제목, 법령명+조문 제목, retry suggestion, router 후보를 사용한 compact query 재검색
- `관련 판례 상세` 섹션
- `자동 상세조회: search_precedents -> get_precedent_text (상위 2건, full=false)` 표시
- 판례의 `판시사항`, `판결요지`, `참조조문`, 축약된 본문

결론적으로 Open WebUI 채팅 인터페이스의 최종 답변 단계가 판례 제목이나 힌트만 보는 것이 아니라, 실제 상세조회 결과를 기반으로 답변할 수 있게 됩니다.

## 사용자 및 개발자 영향

- Open WebUI MCP provider 채팅 환경에서 chain 도구 결과가 더 완결적입니다.
- local model이 다음 상세조회 도구 호출을 놓쳐도 chain 결과 안에 핵심 상세 정보가 포함됩니다.
- 직접 `search_*` 도구는 기존처럼 목록 검색 도구로 유지됩니다.
- public MCP tool schema는 변경하지 않았습니다.
- 기존 CLI 경로의 정책을 재사용하므로 새로운 별도 routing layer를 추가하지 않습니다.
- compact query planner도 공개 MCP tool을 추가하지 않고 chain 내부에서만 사용합니다.

## 테스트

로컬에서 다음 검증을 통과했습니다.

```bash
npm run build
node test/test-search-detail-chain.cjs
node test/test-chain-search-detail-integration.cjs
node test/test-chain-full-research-precedent-retry.cjs
node test/test-compact-query-planner.cjs
```

추가로 local API key를 사용해 위 중고거래 환불 질문으로 수동 API 검증을 수행했습니다.

## 참고

이 PR은 법률 질의 라우터를 새로 만들거나, Claude/Codex 같은 Frontier CLI 모델의 동작을 모방하려는 변경이 아닙니다.

이미 upstream에 존재하는 검색 → 상세조회 정책을 MCP chain 도구에도 적용해, local Open WebUI 채팅 인터페이스에서 누락되던 상세조회 연결을 보완하는 변경입니다. compact query planner 역시 같은 목적의 보조 단계이며, 임의 법률 키워드 사전이 아니라 기존 검색 결과의 구조화 단서를 재사용합니다.
