### PR TITLE
법제처 API 프로토콜 설정 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # 법제처 오픈API 인증키 (필수)
 # 발급: https://www.law.go.kr/DRF/lawService.do
 LAW_OC=your-api-key-here
+
+# 법제처 API 호출 프로토콜 (기본값: https)
+# 폐쇄망/인증서 문제가 있는 환경에서는 http 사용
+LAW_API_PROTOCOL=https

--- a/README.md
+++ b/README.md
@@ -565,6 +565,41 @@ korean-law help search_law                 # 도구별 도움말
 | 환경변수 | `LAW_OC=내키` | 로컬 설치(방법 3, 4) |
 | 도구 파라미터 | `apiKey: "내키"` | 특정 요청만 다른 키 쓸 때 |
 
+### 법제처 API 프로토콜 설정
+
+법제처 API 호출은 기본적으로 HTTPS를 사용합니다. 사내망·폐쇄망 등 인증서 검증이 어려운 환경에서는 `LAW_API_PROTOCOL=http`를 설정해 HTTP로 호출할 수 있습니다.
+
+MCP 클라이언트 설정의 `env` 블록에 함께 넣는 방식이 가장 명확합니다:
+
+```json
+{
+  "mcpServers": {
+    "korean-law": {
+      "command": "korean-law-mcp",
+      "env": {
+        "LAW_OC": "honggildong",
+        "LAW_API_PROTOCOL": "http"
+      }
+    }
+  }
+}
+```
+
+터미널에서 직접 실행하거나 `.env` 파일을 사용할 수도 있습니다:
+
+```bash
+export LAW_API_PROTOCOL=http        # Mac/Linux
+set LAW_API_PROTOCOL=http           # Windows CMD
+$env:LAW_API_PROTOCOL="http"       # Windows PowerShell
+```
+
+```env
+LAW_OC=honggildong
+LAW_API_PROTOCOL=http
+```
+
+허용값은 `http`, `https`입니다. 설정하지 않거나 다른 값을 넣으면 `https`가 사용됩니다.
+
 ---
 
 ## 사용 예시

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -5,8 +5,9 @@
 import { normalizeLawSearchText, resolveLawAlias } from "./search-normalizer.js"
 import { fetchWithRetry } from "./fetch-with-retry.js"
 import { requestContext } from "./session-state.js"
+import { getLawApiBaseUrl } from "./law-url-config.js"
 
-const LAW_API_BASE = "https://www.law.go.kr/DRF"
+const LAW_API_BASE = getLawApiBaseUrl()
 
 export class LawApiClient {
   private defaultApiKey: string

--- a/src/lib/law-url-config.ts
+++ b/src/lib/law-url-config.ts
@@ -1,0 +1,21 @@
+import { config as loadDotenv } from "dotenv"
+
+loadDotenv({ quiet: true })
+
+export type LawApiProtocol = "http" | "https"
+
+const DEFAULT_LAW_API_PROTOCOL: LawApiProtocol = "https"
+
+export function getLawApiProtocol(): LawApiProtocol {
+  const raw = (process.env.LAW_API_PROTOCOL || "").trim().toLowerCase()
+  if (raw === "http" || raw === "https") return raw
+  return DEFAULT_LAW_API_PROTOCOL
+}
+
+export function getLawApiBaseUrl(): string {
+  return `${getLawApiProtocol()}://www.law.go.kr/DRF`
+}
+
+export function getLawSiteBaseUrl(): string {
+  return `${getLawApiProtocol()}://www.law.go.kr`
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,6 +11,7 @@ import { existsSync } from "node:fs"
 import { resolve, dirname } from "node:path"
 import { homedir, platform } from "node:os"
 import { stdin, stdout } from "node:process"
+import { getLawApiProtocol } from "./lib/law-url-config.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,10 +113,13 @@ async function writeJsonFile(path: string, data: Record<string, unknown>): Promi
   await writeFile(path, JSON.stringify(data, null, 2) + "\n", "utf-8")
 }
 
-function buildServerEntry(apiKey: string): Record<string, unknown> {
+function buildServerEntry(apiKey: string, lawApiProtocol = getLawApiProtocol()): Record<string, unknown> {
   const env: Record<string, string> = {}
   if (apiKey) {
     env.LAW_OC = apiKey
+  }
+  if (lawApiProtocol === "http") {
+    env.LAW_API_PROTOCOL = lawApiProtocol
   }
   return {
     command: "npx",
@@ -125,10 +129,13 @@ function buildServerEntry(apiKey: string): Record<string, unknown> {
 }
 
 /** Zed는 context_servers 키에 { command: { path, args, env } } 구조 */
-function buildZedEntry(apiKey: string): Record<string, unknown> {
+function buildZedEntry(apiKey: string, lawApiProtocol = getLawApiProtocol()): Record<string, unknown> {
   const env: Record<string, string> = {}
   if (apiKey) {
     env.LAW_OC = apiKey
+  }
+  if (lawApiProtocol === "http") {
+    env.LAW_API_PROTOCOL = lawApiProtocol
   }
   return {
     command: {
@@ -297,7 +304,8 @@ export async function runSetup(): Promise<void> {
     // Step 3: 설정 파일 업데이트
     console.log()
     stepHeader(3, 3, "설정 파일 업데이트")
-    const entry = buildServerEntry(apiKey)
+    const lawApiProtocol = getLawApiProtocol()
+    const entry = buildServerEntry(apiKey, lawApiProtocol)
 
     for (const idx of indices) {
       const client = clients[idx]
@@ -305,7 +313,7 @@ export async function runSetup(): Promise<void> {
       try {
         const config = await readJsonFile(client.configPath)
         const key = client.format
-        const serverEntry = key === "context_servers" ? buildZedEntry(apiKey) : entry
+        const serverEntry = key === "context_servers" ? buildZedEntry(apiKey, lawApiProtocol) : entry
         const servers = (config[key] ?? {}) as Record<string, unknown>
         servers["korean-law"] = serverEntry
         config[key] = servers

--- a/src/tools/annex.ts
+++ b/src/tools/annex.ts
@@ -8,6 +8,7 @@ import { fetchWithRetry } from "../lib/fetch-with-retry.js"
 import { parseAnnexFile } from "../lib/annex-file-parser.js"
 import { truncateResponse, MAX_RESPONSE_SIZE } from "../lib/schemas.js"
 import { formatToolError, notFoundResponse } from "../lib/errors.js"
+import { getLawSiteBaseUrl } from "../lib/law-url-config.js"
 
 /** 법제처 별표/서식 API 응답 개별 항목 */
 interface AnnexItem {
@@ -26,7 +27,7 @@ interface AnnexItem {
   지자체기관명?: string
 }
 
-const LAW_BASE_URL = "https://www.law.go.kr"
+const LAW_BASE_URL = getLawSiteBaseUrl()
 
 export const GetAnnexesSchema = z.object({
   lawName: z.string().describe("법령명 (예: '관세법'). 별표를 바로 지정하려면 '... 별표4'처럼 함께 입력 가능"),

--- a/src/tools/external-links.ts
+++ b/src/tools/external-links.ts
@@ -5,6 +5,7 @@
 import { z } from "zod"
 import { truncateResponse } from "../lib/schemas.js"
 import { formatToolError } from "../lib/errors.js"
+import { getLawSiteBaseUrl } from "../lib/law-url-config.js"
 
 export const ExternalLinksSchema = z.object({
   linkType: z.enum(["law", "precedent", "interpretation", "ordinance", "admin_rule"]).describe(
@@ -21,6 +22,8 @@ export const ExternalLinksSchema = z.object({
 })
 
 export type ExternalLinksInput = z.infer<typeof ExternalLinksSchema>
+
+const LAW_BASE_URL = getLawSiteBaseUrl()
 
 export async function getExternalLinks(
   input: ExternalLinksInput
@@ -140,31 +143,31 @@ function generateLawLinks(lawId?: string, mst?: string, lawName?: string, jo?: s
   // 1. 한글 URL (법령명 기반) - 우선순위 최상위
   if (lawName) {
     if (jo) {
-      const url = `https://www.law.go.kr/법령/${encodeURIComponent(lawName)}/${encodeURIComponent(jo)}`
+      const url = `${LAW_BASE_URL}/법령/${encodeURIComponent(lawName)}/${encodeURIComponent(jo)}`
       links += `${linkNum++}. [법제처 조문 직접 링크](${url})\n\n`
     } else {
-      const url = `https://www.law.go.kr/법령/${encodeURIComponent(lawName)}`
+      const url = `${LAW_BASE_URL}/법령/${encodeURIComponent(lawName)}`
       links += `${linkNum++}. [법제처 법령 직접 링크](${url})\n\n`
     }
   }
 
   // 2. 법령ID 기반 링크 (쿼리 파라미터)
   if (lawId) {
-    const detailUrl = `https://www.law.go.kr/LSW/lawLsInfoP.do?lsiSeq=${lawId}`
+    const detailUrl = `${LAW_BASE_URL}/LSW/lawLsInfoP.do?lsiSeq=${lawId}`
     links += `${linkNum++}. [법제처 법령 상세 (ID)](${detailUrl})\n\n`
 
-    const engUrl = `https://www.law.go.kr/eng/LSW/lawLsInfoP.do?lsiSeq=${lawId}`
+    const engUrl = `${LAW_BASE_URL}/eng/LSW/lawLsInfoP.do?lsiSeq=${lawId}`
     links += `${linkNum++}. [법령 전문 (영문)](${engUrl})\n\n`
   }
 
   // 3. 법령 연혁
   if (mst) {
-    const historyUrl = `https://www.law.go.kr/LSW/lsStmdInfoP.do?lsiSeq=${mst}`
+    const historyUrl = `${LAW_BASE_URL}/LSW/lsStmdInfoP.do?lsiSeq=${mst}`
     links += `${linkNum++}. [법령 연혁](${historyUrl})\n\n`
   }
 
   // 4. 법제처 홈페이지
-  links += `${linkNum}. [법제처 홈페이지](https://www.law.go.kr/)\n\n`
+  links += `${linkNum}. [법제처 홈페이지](${LAW_BASE_URL}/)\n\n`
 
   return links
 }
@@ -175,7 +178,7 @@ function generateLawLinks(lawId?: string, mst?: string, lawName?: string, jo?: s
 function generatePrecedentLinks(precedentId: string): string {
   let links = "판례 관련 링크:\n\n"
 
-  const lawUrl = `https://www.law.go.kr/LSW/precInfoP.do?precSeq=${precedentId}`
+  const lawUrl = `${LAW_BASE_URL}/LSW/precInfoP.do?precSeq=${precedentId}`
   links += `1. [법제처 판례 상세](${lawUrl})\n\n`
 
   links += `2. [대법원 종합법률정보](https://glaw.scourt.go.kr/)\n`
@@ -192,7 +195,7 @@ function generatePrecedentLinks(precedentId: string): string {
 function generateInterpretationLinks(interpretationId: string): string {
   let links = "법령해석례 관련 링크:\n\n"
 
-  const detailUrl = `https://www.law.go.kr/LSW/lsExpcInfoP.do?lsExpcSeq=${interpretationId}`
+  const detailUrl = `${LAW_BASE_URL}/LSW/lsExpcInfoP.do?lsExpcSeq=${interpretationId}`
   links += `1. [법제처 해석례 상세](${detailUrl})\n\n`
 
   links += `2. [법제처 법령해석](https://www.moleg.go.kr/)\n\n`
@@ -210,28 +213,28 @@ function generateOrdinanceLinks(ordinanceId?: string, mst?: string, lawName?: st
   // 1. 한글 URL (법령명 기반)
   if (lawName) {
     if (jo) {
-      const url = `https://www.law.go.kr/자치법규/${encodeURIComponent(lawName)}/${encodeURIComponent(jo)}`
+      const url = `${LAW_BASE_URL}/자치법규/${encodeURIComponent(lawName)}/${encodeURIComponent(jo)}`
       links += `${linkNum++}. [법제처 조문 직접 링크](${url})\n\n`
     } else {
-      const url = `https://www.law.go.kr/자치법규/${encodeURIComponent(lawName)}`
+      const url = `${LAW_BASE_URL}/자치법규/${encodeURIComponent(lawName)}`
       links += `${linkNum++}. [법제처 자치법규 직접 링크](${url})\n\n`
     }
   }
 
   // 2. 자치법규ID 기반 링크
   if (ordinanceId) {
-    const detailUrl = `https://www.law.go.kr/LSW/ordinInfoP.do?ordinSeq=${ordinanceId}`
+    const detailUrl = `${LAW_BASE_URL}/LSW/ordinInfoP.do?ordinSeq=${ordinanceId}`
     links += `${linkNum++}. [법제처 자치법규 상세 (ID)](${detailUrl})\n\n`
   }
 
   // 3. 자치법규 연혁
   if (mst) {
-    const historyUrl = `https://www.law.go.kr/LSW/lsStmdInfoP.do?lsiSeq=${mst}`
+    const historyUrl = `${LAW_BASE_URL}/LSW/lsStmdInfoP.do?lsiSeq=${mst}`
     links += `${linkNum++}. [자치법규 연혁](${historyUrl})\n\n`
   }
 
   // 4. 국가법령정보센터 자치법규
-  links += `${linkNum++}. [국가법령정보센터 자치법규](https://www.law.go.kr/LSW/lsRvsRqInfoListP.do)\n\n`
+  links += `${linkNum++}. [국가법령정보센터 자치법규](${LAW_BASE_URL}/LSW/lsRvsRqInfoListP.do)\n\n`
 
   // 5. 자치법규정보시스템 (ELIS)
   links += `${linkNum}. [자치법규정보시스템 (ELIS)](https://www.elis.go.kr/)\n\n`
@@ -245,12 +248,12 @@ function generateOrdinanceLinks(ordinanceId?: string, mst?: string, lawName?: st
 function generateAdminRuleLinks(adminRuleId: string): string {
   let links = "행정규칙 관련 링크:\n\n"
 
-  const detailUrl = `https://www.law.go.kr/LSW/admRulInfoP.do?admRulSeq=${adminRuleId}`
+  const detailUrl = `${LAW_BASE_URL}/LSW/admRulInfoP.do?admRulSeq=${adminRuleId}`
   links += `1. [법제처 행정규칙 상세](${detailUrl})\n\n`
 
-  links += `2. [국가법령정보센터 행정규칙](https://www.law.go.kr/LSW/admRulLsInfoP.do)\n\n`
+  links += `2. [국가법령정보센터 행정규칙](${LAW_BASE_URL}/LSW/admRulLsInfoP.do)\n\n`
 
-  links += `3. [법제처 홈페이지](https://www.law.go.kr/)\n\n`
+  links += `3. [법제처 홈페이지](${LAW_BASE_URL}/)\n\n`
 
   return links
 }

--- a/test/test-law-url-config.cjs
+++ b/test/test-law-url-config.cjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { pathToFileURL } = require("url")
+const { spawnSync } = require("child_process")
+
+async function main() {
+  const { getLawApiBaseUrl, getLawApiProtocol, getLawSiteBaseUrl } = await import("../build/lib/law-url-config.js")
+
+  const previous = process.env.LAW_API_PROTOCOL
+  try {
+    delete process.env.LAW_API_PROTOCOL
+    assert.strictEqual(getLawApiProtocol(), "https")
+    assert.strictEqual(getLawApiBaseUrl(), "https://www.law.go.kr/DRF")
+    assert.strictEqual(getLawSiteBaseUrl(), "https://www.law.go.kr")
+
+    process.env.LAW_API_PROTOCOL = "http"
+    assert.strictEqual(getLawApiProtocol(), "http")
+    assert.strictEqual(getLawApiBaseUrl(), "http://www.law.go.kr/DRF")
+    assert.strictEqual(getLawSiteBaseUrl(), "http://www.law.go.kr")
+
+    process.env.LAW_API_PROTOCOL = "https"
+    assert.strictEqual(getLawApiProtocol(), "https")
+    assert.strictEqual(getLawApiBaseUrl(), "https://www.law.go.kr/DRF")
+
+    process.env.LAW_API_PROTOCOL = "invalid"
+    assert.strictEqual(getLawApiProtocol(), "https")
+  } finally {
+    if (previous === undefined) delete process.env.LAW_API_PROTOCOL
+    else process.env.LAW_API_PROTOCOL = previous
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "korean-law-env-"))
+  fs.writeFileSync(path.join(tempDir, ".env"), "LAW_API_PROTOCOL=http\n", "utf8")
+  const moduleUrl = pathToFileURL(path.resolve(__dirname, "../build/lib/law-url-config.js")).href
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `const m = await import(${JSON.stringify(moduleUrl)}); console.log(m.getLawApiBaseUrl());`,
+    ],
+    {
+      cwd: tempDir,
+      encoding: "utf8",
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => key !== "LAW_API_PROTOCOL")
+      ),
+    }
+  )
+  assert.strictEqual(child.status, 0, child.stderr)
+  assert.strictEqual(child.stdout.trim(), "http://www.law.go.kr/DRF")
+
+  console.log("law URL protocol config tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## 배경

운영 환경에 따라 법제처 Open API의 HTTPS 연결이 인증서/망 정책 문제로 실패할 수 있습니다. 이 경우 `LAW_API_PROTOCOL=http`로 우회할 수 있어야 하지만, 기존 코드는 법제처 DRF API 주소를 `https://www.law.go.kr/DRF`로 고정해 환경변수 설정이 실제 호출에 반영되지 않았습니다.

## 변경 내용

- `LAW_API_PROTOCOL` 환경변수로 법제처 API 호출 프로토콜을 `http` 또는 `https` 중 선택할 수 있게 했습니다.
- 기본값은 기존 동작과 같은 `https`이며, 잘못된 값도 안전하게 `https`로 fallback합니다.
- DRF API 호출, 별표 파일 링크, 법제처 출력 링크가 같은 프로토콜 설정을 사용하도록 공통 URL 설정 모듈을 추가했습니다.
- `.env.example`, README, setup 생성 설정에 사용 방법을 문서화했습니다.

## 검증

- `npm run build`
- `node test/test-law-url-config.cjs`
- `LAW_API_PROTOCOL=http` 설정 후 `LawApiClient.searchLaw()`가 `http://www.law.go.kr/DRF/lawSearch.do`로 호출 URL을 만드는지 mock fetch로 확인했습니다.