### PR TITLE
판례 재검색 키워드 후보 생성 개선

### DIFF
--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -21,7 +21,7 @@ import type { ScenarioType, ScenarioContext } from "./scenarios/index.js"
 import { analyzeDocument } from "./document-analysis.js"
 import { getThreeTier } from "./three-tier.js"
 import { getBatchArticles } from "./batch-articles.js"
-import { searchPrecedents } from "./precedents.js"
+import { getPrecedentText, searchPrecedents } from "./precedents.js"
 import { summarizePrecedent } from "./precedent-summary.js"
 import { searchInterpretations } from "./interpretations.js"
 import { searchAdminAppeals } from "./admin-appeals.js"
@@ -30,12 +30,12 @@ import { getArticleHistory } from "./article-history.js"
 import { searchOrdinance } from "./ordinance-search.js"
 import { getOrdinance } from "./ordinance.js"
 import { getAnnexes } from "./annex.js"
-import { searchAiLaw } from "./life-law.js"
+import { searchAiLaw, searchAiLawStructured, type AiLawArticleSignal, type SearchAiLawInput } from "./life-law.js"
 import { getLawText } from "./law-text.js"
 import { searchTaxTribunalDecisions } from "./tax-tribunal-decisions.js"
 import { searchNlrcDecisions, searchPipcDecisions } from "./committee-decisions.js"
 import { fetchSearchDetailChain, fetchCombinedSearchDetailChain } from "./search-detail-chain.js"
-import { buildCompactLegalQueries } from "./compact-query-planner.js"
+import { buildCompactLegalQueries, type CompactQueryCandidate } from "./compact-query-planner.js"
 
 // ========================================
 // Types
@@ -44,6 +44,7 @@ import { buildCompactLegalQueries } from "./compact-query-planner.js"
 interface CallResult {
   text: string
   isError: boolean
+  aiLawArticles?: AiLawArticleSignal[]
 }
 
 type DomainType = "customs" | "tax" | "labor" | "privacy" | "competition"
@@ -65,6 +66,22 @@ async function callTool(
   try {
     const result = await handler(apiClient, input)
     return { text: result.content?.[0]?.text || "", isError: !!result.isError }
+  } catch (e) {
+    return { text: `오류: ${e instanceof Error ? e.message : String(e)}`, isError: true }
+  }
+}
+
+async function callAiLaw(
+  apiClient: LawApiClient,
+  input: SearchAiLawInput
+): Promise<CallResult> {
+  try {
+    const result = await searchAiLawStructured(apiClient, input)
+    return {
+      text: result.response.content?.[0]?.text || "",
+      isError: !!result.response.isError,
+      aiLawArticles: result.articleSignals,
+    }
   } catch (e) {
     return { text: `오류: ${e instanceof Error ? e.message : String(e)}`, isError: true }
   }
@@ -155,6 +172,70 @@ function selectLawTextSource(laws: LawInfo[], query: string): { reliableLaws: La
   return { reliableLaws, textLaw: laws[0], lowConfidence: laws.length > 0 }
 }
 
+function normalizeRelevanceText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, "")
+}
+
+function candidateRelevanceTerms(candidate: CompactQueryCandidate): string[] {
+  return Array.from(new Set([candidate.query, candidate.semanticAnchor]
+    .filter((term): term is string => typeof term === "string" && normalizeRelevanceText(term).length >= 2)))
+}
+
+function textContainsCandidateTerm(text: string, candidate: CompactQueryCandidate): boolean {
+  const haystack = normalizeRelevanceText(text)
+  return candidateRelevanceTerms(candidate)
+    .some(term => haystack.includes(normalizeRelevanceText(term)))
+}
+
+function extractPrecedentCaseLines(searchText: string): string[] {
+  return searchText
+    .split("\n")
+    .filter(line => /^\[\d+\]\s+/.test(line.trim()))
+}
+
+function extractFirstPrecedentId(searchText: string): string | undefined {
+  for (const line of searchText.split("\n")) {
+    const match = line.trim().match(/^\[(\d+)\]\s+/)
+    if (match?.[1]) return match[1]
+  }
+  return undefined
+}
+
+async function validateRetryPrecedentResult(
+  apiClient: LawApiClient,
+  candidate: CompactQueryCandidate,
+  result: CallResult,
+  apiKey?: string
+): Promise<boolean> {
+  const caseLines = extractPrecedentCaseLines(result.text)
+  if (caseLines.some(line => textContainsCandidateTerm(line, candidate))) {
+    return true
+  }
+
+  if (candidate.search !== 2 && !candidate.requiresResultValidation) {
+    return false
+  }
+
+  const id = extractFirstPrecedentId(result.text)
+  if (!id) return false
+
+  const detail = await callTool(getPrecedentText, apiClient, {
+    id,
+    full: candidate.search === 2,
+    apiKey,
+  })
+  if (isSearchFailure(detail) || !detail.text.trim()) return false
+
+  return textContainsCandidateTerm(detail.text, candidate)
+}
+
+function formatRetryCandidate(candidate: CompactQueryCandidate): string {
+  return candidate.search === 2 ? `"${candidate.query}"(본문검색)` : `"${candidate.query}"`
+}
+
 async function retryPrecedentsIfNeeded(
   apiClient: LawApiClient,
   input: { query: string; apiKey?: string },
@@ -166,23 +247,25 @@ async function retryPrecedentsIfNeeded(
   const route = routeQuery(input.query)
   const candidates = buildCompactLegalQueries({
     originalQuery: input.query,
+    aiLawArticles: aiLawResult?.aiLawArticles,
     aiLawText: aiLawResult?.text,
     route,
     failedSearchText: precedentResult.text,
     max: PRECEDENT_RETRY_LIMIT,
-  }).map(candidate => candidate.query)
+  })
 
   if (candidates.length === 0) return precedentResult
 
-  for (const query of candidates) {
+  for (const candidate of candidates) {
     const retried = await callTool(searchPrecedents, apiClient, {
-      query,
+      query: candidate.query,
+      search: candidate.search,
       display: 5,
       apiKey: input.apiKey,
     })
-    if (!isSearchFailure(retried) && retried.text.trim()) {
+    if (!isSearchFailure(retried) && retried.text.trim() && await validateRetryPrecedentResult(apiClient, candidate, retried, input.apiKey)) {
       return {
-        text: `판례 1차 검색 실패 후 재검색어 "${query}"로 조회했습니다.\n\n${retried.text}`,
+        text: `판례 1차 검색 실패 후 재검색어 "${candidate.query}"로 조회했습니다.\n\n${retried.text}`,
         isError: false,
       }
     }
@@ -192,7 +275,7 @@ async function retryPrecedentsIfNeeded(
     text: [
       precedentResult.text,
       "",
-      `재검색 시도(최대 ${PRECEDENT_RETRY_LIMIT}회): ${candidates.map(query => `"${query}"`).join(", ")}`,
+      `재검색 시도(최대 ${PRECEDENT_RETRY_LIMIT}회): ${candidates.map(formatRetryCandidate).join(", ")}`,
       "모든 재검색에서 판례 검색 결과가 없습니다.",
     ].join("\n"),
     isError: true,
@@ -586,7 +669,7 @@ export async function chainFullResearch(
       catch { return [] }
     }
     const [aiResult, rawLawsResult, precResult, interpResult] = await Promise.all([
-      callTool(searchAiLaw, apiClient, { query: input.query, display: 10, apiKey: input.apiKey }),
+      callAiLaw(apiClient, { query: input.query, search: "0", display: 10, page: 1, apiKey: input.apiKey }),
       safeFindLaws(),
       callTool(searchPrecedents, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
       callTool(searchInterpretations, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),

--- a/src/tools/compact-query-planner.ts
+++ b/src/tools/compact-query-planner.ts
@@ -1,7 +1,19 @@
+import type { AiLawArticleSignal } from "./life-law.js"
+
 export type CompactQuerySource =
   | "ai_law_article_title"
   | "ai_law_law_article_title"
   | "search_retry_hint"
+  | "router"
+
+export type PrecedentSearchScope = 1 | 2
+
+export type CompactQueryVariantKind =
+  | "raw"
+  | "terminal_function_word_removed"
+  | "terminal_function_word_spaced"
+  | "law_title"
+  | "retry_hint"
   | "router"
 
 export interface CompactQueryCandidate {
@@ -9,6 +21,10 @@ export interface CompactQueryCandidate {
   source: CompactQuerySource
   score: number
   reason: string
+  search: PrecedentSearchScope
+  semanticAnchor?: string
+  variantKind: CompactQueryVariantKind
+  requiresResultValidation: boolean
 }
 
 interface RouteLike {
@@ -18,17 +34,30 @@ interface RouteLike {
 
 export interface CompactQueryInput {
   originalQuery: string
+  aiLawArticles?: AiLawArticleSignal[]
   aiLawText?: string
   route?: RouteLike
   failedSearchText?: string
   max?: number
 }
 
+const LOW_INFORMATION_ARTICLE_TITLES = new Set([
+  "목적",
+  "정의",
+  "용어의 정의",
+  "적용 범위",
+  "적용범위",
+  "다른 법률과의 관계",
+  "다른 법률과의 관계 등",
+  "벌칙",
+  "과태료",
+  "시행일",
+])
+
+const MIN_AI_ARTICLE_SCORE = 90
+
 function normalizeArticleTitle(title: string): string {
-  return title
-    .replace(/등(?:의)?\s*(효과|제한|기준|방법|절차)?$/g, "")
-    .replace(/의\s*(내용|효과|기준|범위)$/g, "")
-    .trim()
+  return normalizeCandidate(title)
 }
 
 function normalizeCandidate(query: string): string {
@@ -51,6 +80,104 @@ function isUsefulCandidate(candidate: string, originalQuery: string): boolean {
   return true
 }
 
+function isGenericArticleTitle(title: string): boolean {
+  const normalized = normalizeCandidate(title)
+  return LOW_INFORMATION_ARTICLE_TITLES.has(normalized)
+}
+
+function supportTokens(text: string): string[] {
+  return Array.from(new Set(
+    normalizeCandidate(text)
+      .replace(/<[^>]*>/g, " ")
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .split(/\s+/)
+      .map(token => token.replace(/(에서|에게|으로|로서|로써|부터|까지|합니다|해달라고)$/u, ""))
+      .filter(token => token.length >= 2)
+  ))
+}
+
+function scoreAiLawArticleCandidate(
+  article: AiLawArticleSignal,
+  originalQuery: string,
+  query: string,
+  source: CompactQuerySource
+): number {
+  let score = source === "ai_law_article_title" ? 100 : 85
+  const title = normalizeCandidate(query.replace(article.lawName, "").trim() || query)
+  const normalizedOriginal = normalizeCandidate(originalQuery)
+  const queryTokens = supportTokens(originalQuery)
+  const content = normalizeCandidate(article.articleContent)
+
+  if (title.length >= 2 && title.length <= 12) score += 10
+  else if (title.length > 12) score += 15
+
+  if (normalizedOriginal.includes(title)) {
+    score += 35
+  } else if (queryTokens.some(token => title.includes(token) || token.includes(title))) {
+    score += 20
+  }
+
+  if (article.lawName && normalizedOriginal.includes(article.lawName)) {
+    score += 20
+  }
+
+  const contentHits = queryTokens.filter(token => content.includes(token)).length
+  if (contentHits >= 2 && content.includes(title)) score += 15
+  else if (contentHits >= 2) score += 10
+  else if (contentHits === 1) score += 5
+
+  if (isGenericArticleTitle(title)) score -= 80
+
+  score += Math.max(0, 8 - article.sourceIndex)
+
+  return score
+}
+
+interface TitleVariant {
+  query: string
+  search: PrecedentSearchScope
+  variantKind: CompactQueryVariantKind
+  scoreDelta: number
+  requiresResultValidation: boolean
+}
+
+function titleVariants(title: string): TitleVariant[] {
+  const normalized = normalizeArticleTitle(title)
+  if (!normalized) return []
+  const compactTerminalDeung = normalized.match(/^([가-힣A-Za-z0-9]{4,})등$/u)
+  const spacedTerminalDeung = normalized.match(/^([가-힣A-Za-z0-9]{4,})\s+등$/u)
+  const terminalStem = compactTerminalDeung?.[1] || spacedTerminalDeung?.[1]
+
+  const variants: TitleVariant[] = [{
+    query: normalized,
+    search: spacedTerminalDeung ? 2 : 1,
+    variantKind: "raw",
+    scoreDelta: -5,
+    requiresResultValidation: !!spacedTerminalDeung,
+  }]
+
+  if (terminalStem) {
+    variants.push({
+      query: terminalStem,
+      search: 1,
+      variantKind: "terminal_function_word_removed",
+      scoreDelta: 18,
+      requiresResultValidation: true,
+    })
+    if (!spacedTerminalDeung) {
+      variants.push({
+        query: `${terminalStem} 등`,
+        search: 2,
+        variantKind: "terminal_function_word_spaced",
+        scoreDelta: 8,
+        requiresResultValidation: true,
+      })
+    }
+  }
+
+  return variants
+}
+
 function pushCandidate(
   out: CompactQueryCandidate[],
   seen: Set<string>,
@@ -58,13 +185,30 @@ function pushCandidate(
   query: string,
   source: CompactQuerySource,
   score: number,
-  reason: string
+  reason: string,
+  options: {
+    search?: PrecedentSearchScope
+    semanticAnchor?: string
+    variantKind?: CompactQueryVariantKind
+    requiresResultValidation?: boolean
+  } = {}
 ): void {
   const normalized = normalizeCandidate(query)
+  const search = options.search ?? 1
   if (!isUsefulCandidate(normalized, originalQuery)) return
-  if (seen.has(normalized)) return
-  seen.add(normalized)
-  out.push({ query: normalized, source, score, reason })
+  const key = `${search}:${normalized}`
+  if (seen.has(key)) return
+  seen.add(key)
+  out.push({
+    query: normalized,
+    source,
+    score,
+    reason,
+    search,
+    semanticAnchor: options.semanticAnchor,
+    variantKind: options.variantKind ?? (source === "router" ? "router" : source === "search_retry_hint" ? "retry_hint" : "raw"),
+    requiresResultValidation: options.requiresResultValidation ?? false,
+  })
 }
 
 function addAiLawArticleCandidates(
@@ -88,28 +232,94 @@ function addAiLawArticleCandidates(
     if (!titleMatch) continue
 
     const title = normalizeArticleTitle(titleMatch[1])
-    if (!title) continue
-
-    pushCandidate(
-      out,
-      seen,
-      originalQuery,
-      title,
-      "ai_law_article_title",
-      100,
-      "AI 법령검색 조문 제목"
-    )
-
-    if (currentLawName) {
+    const variants = titleVariants(title)
+    for (const variant of variants) {
       pushCandidate(
         out,
         seen,
         originalQuery,
-        `${currentLawName} ${title}`,
-        "ai_law_law_article_title",
-        90,
-        "AI 법령검색 법령명 + 조문 제목"
+        variant.query,
+        "ai_law_article_title",
+        100 + variant.scoreDelta,
+        "AI 법령검색 조문 제목",
+        {
+          search: variant.search,
+          semanticAnchor: title,
+          variantKind: variant.variantKind,
+          requiresResultValidation: variant.requiresResultValidation,
+        }
       )
+
+      if (currentLawName && variant.search === 1) {
+        pushCandidate(
+          out,
+          seen,
+          originalQuery,
+          `${currentLawName} ${variant.query}`,
+          "ai_law_law_article_title",
+          90 + variant.scoreDelta,
+          "AI 법령검색 법령명 + 조문 제목",
+          {
+            search: 1,
+            semanticAnchor: title,
+            variantKind: "law_title",
+            requiresResultValidation: variant.requiresResultValidation,
+          }
+        )
+      }
+    }
+  }
+}
+
+function addStructuredAiLawArticleCandidates(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string,
+  articles: AiLawArticleSignal[]
+): void {
+  for (const article of articles) {
+    const title = normalizeArticleTitle(article.articleTitle)
+    if (!title) continue
+    for (const variant of titleVariants(title)) {
+      const score = scoreAiLawArticleCandidate(article, originalQuery, variant.query, "ai_law_article_title") + variant.scoreDelta
+      if (score < MIN_AI_ARTICLE_SCORE) continue
+
+      pushCandidate(
+        out,
+        seen,
+        originalQuery,
+        variant.query,
+        "ai_law_article_title",
+        score,
+        "AI 법령검색 raw 조문 제목",
+        {
+          search: variant.search,
+          semanticAnchor: title,
+          variantKind: variant.variantKind,
+          requiresResultValidation: variant.requiresResultValidation,
+        }
+      )
+
+      if (article.lawName && variant.search === 1) {
+        const lawTitle = `${article.lawName} ${variant.query}`
+        const lawTitleScore = scoreAiLawArticleCandidate(article, originalQuery, lawTitle, "ai_law_law_article_title") + variant.scoreDelta
+        if (lawTitleScore < MIN_AI_ARTICLE_SCORE) continue
+        pushCandidate(
+          out,
+          seen,
+          originalQuery,
+          lawTitle,
+          "ai_law_law_article_title",
+          lawTitleScore,
+          "AI 법령검색 raw 법령명 + 조문 제목",
+          {
+            search: 1,
+            semanticAnchor: title,
+            variantKind: "law_title",
+            requiresResultValidation: variant.requiresResultValidation,
+          }
+        )
+      }
     }
   }
 }
@@ -130,7 +340,8 @@ function addRetrySuggestionCandidates(
         match[1],
         "search_retry_hint",
         80,
-        "검색 실패 응답의 재시도 제안"
+        "검색 실패 응답의 재시도 제안",
+        { variantKind: "retry_hint" }
       )
     }
   }
@@ -151,7 +362,8 @@ function addRouteCandidates(
       value,
       "router",
       70,
-      "query-router 후보"
+      "query-router 후보",
+      { variantKind: "router" }
     )
   }
 
@@ -167,7 +379,9 @@ export function buildCompactLegalQueries(input: CompactQueryInput): CompactQuery
   const seen = new Set<string>()
   const candidates: CompactQueryCandidate[] = []
 
-  if (input.aiLawText) {
+  if (input.aiLawArticles && input.aiLawArticles.length > 0) {
+    addStructuredAiLawArticleCandidates(candidates, seen, input.originalQuery, input.aiLawArticles)
+  } else if (input.aiLawText) {
     addAiLawArticleCandidates(candidates, seen, input.originalQuery, input.aiLawText)
   }
   if (input.failedSearchText) {
@@ -177,5 +391,6 @@ export function buildCompactLegalQueries(input: CompactQueryInput): CompactQuery
     addRouteCandidates(candidates, seen, input.originalQuery, input.route)
   }
 
+  candidates.sort((a, b) => b.score - a.score)
   return candidates.slice(0, input.max ?? 5)
 }

--- a/src/tools/life-law.ts
+++ b/src/tools/life-law.ts
@@ -3,6 +3,7 @@ import type { LawApiClient } from "../lib/api-client.js";
 import { truncateResponse, formatDateDot } from "../lib/schemas.js";
 import { parseSearchXML, extractTag as sharedExtractTag } from "../lib/xml-parser.js";
 import { formatToolError, noResultHint } from "../lib/errors.js";
+import type { ToolResponse } from "../lib/types.js";
 
 // AI-powered intelligent law search tool
 // 이름은 searchAiLaw가 더 정확하지만, 호환성을 위해 searchLifeLaw alias 유지
@@ -21,135 +22,217 @@ export const searchAiLawSchema = z.object({
 
 export type SearchAiLawInput = z.infer<typeof searchAiLawSchema>;
 
+type AiLawSearchType = SearchAiLawInput["search"];
+
+interface AiLawParsedItem {
+  시행일자: string;
+  법령ID?: string;
+  법령명?: string;
+  법령종류명?: string;
+  소관부처명?: string;
+  조문번호?: string;
+  조문가지번호?: string;
+  조문제목?: string;
+  조문내용?: string;
+  행정규칙ID?: string;
+  행정규칙명?: string;
+  발령기관명?: string;
+  별표서식번호?: string;
+  별표서식제목?: string;
+  별표서식구분명?: string;
+}
+
+export interface AiLawArticleSignal {
+  lawName: string;
+  articleNo: string;
+  articleBranchNo?: string;
+  articleTitle: string;
+  articleContent: string;
+  effectiveDate: string;
+  sourceIndex: number;
+}
+
+export interface ParsedAiLawSearch {
+  totalCount: number;
+  items: AiLawParsedItem[];
+  articleSignals: AiLawArticleSignal[];
+}
+
+export interface SearchAiLawStructuredResult {
+  response: ToolResponse;
+  articleSignals: AiLawArticleSignal[];
+}
+
+const itemTagMap: Record<AiLawSearchType, string> = {
+  "0": "법령조문",
+  "1": "법령별표서식",
+  "2": "행정규칙조문",
+  "3": "행정규칙별표서식",
+};
+
+export function parseAiLawSearchXml(xmlText: string, searchType: AiLawSearchType = "0"): ParsedAiLawSearch {
+  const itemTag = itemTagMap[searchType] || "법령조문";
+
+  const { totalCnt: totalCount, items: parsedItems } = parseSearchXML(
+    xmlText, "aiSearch", itemTag,
+    (itemContent) => {
+      const extractField = (tag: string) => sharedExtractTag(itemContent, tag);
+      const item: AiLawParsedItem = { 시행일자: extractField("시행일자") };
+
+      if (searchType === "0") {
+        item.법령ID = extractField("법령ID");
+        item.법령명 = extractField("법령명");
+        item.법령종류명 = extractField("법령종류명");
+        item.소관부처명 = extractField("소관부처명");
+        item.조문번호 = extractField("조문번호");
+        item.조문가지번호 = extractField("조문가지번호");
+        item.조문제목 = extractField("조문제목");
+        item.조문내용 = extractField("조문내용");
+      } else if (searchType === "1") {
+        item.법령ID = extractField("법령ID");
+        item.법령명 = extractField("법령명");
+        item.별표서식번호 = extractField("별표서식번호");
+        item.별표서식제목 = extractField("별표서식제목");
+        item.별표서식구분명 = extractField("별표서식구분명");
+      } else if (searchType === "2") {
+        item.행정규칙ID = extractField("행정규칙ID");
+        item.행정규칙명 = extractField("행정규칙명");
+        item.발령기관명 = extractField("발령기관명");
+        item.조문번호 = extractField("조문번호");
+        item.조문가지번호 = extractField("조문가지번호");
+        item.조문제목 = extractField("조문제목");
+        item.조문내용 = extractField("조문내용");
+      } else {
+        item.행정규칙ID = extractField("행정규칙ID");
+        item.행정규칙명 = extractField("행정규칙명");
+        item.별표서식번호 = extractField("별표서식번호");
+        item.별표서식제목 = extractField("별표서식제목");
+        item.별표서식구분명 = extractField("별표서식구분명");
+      }
+      return item;
+    },
+    { totalTag: "검색결과개수" }
+  );
+
+  const items = parsedItems as AiLawParsedItem[];
+  const articleSignals = items
+    .map((item, sourceIndex): AiLawArticleSignal | null => {
+      const lawName = item.법령명 || item.행정규칙명 || "";
+      if (!lawName || !item.조문제목 || !item.조문번호) return null;
+      return {
+        lawName,
+        articleNo: item.조문번호,
+        articleBranchNo: item.조문가지번호 || undefined,
+        articleTitle: item.조문제목,
+        articleContent: item.조문내용 || "",
+        effectiveDate: item.시행일자,
+        sourceIndex,
+      };
+    })
+    .filter((item): item is AiLawArticleSignal => item !== null);
+
+  return { totalCount, items, articleSignals };
+}
+
+function renderAiLawSearchResult(
+  args: SearchAiLawInput,
+  searchType: AiLawSearchType,
+  totalCount: number,
+  parsedItems: AiLawParsedItem[]
+): ToolResponse {
+  let items = parsedItems;
+
+  // lawTypes 필터 적용 (클라이언트 사이드)
+  if (args.lawTypes && args.lawTypes.length > 0 && items.length > 0) {
+    const typeSet = new Set(args.lawTypes.map((t: string) => t.trim()));
+    items = items.filter((item: AiLawParsedItem) => {
+      const kind = item.법령종류명 || "";
+      return typeSet.has(kind);
+    });
+  }
+
+  if (totalCount === 0 || items.length === 0) {
+    return noResultHint(args.query || "", "생활법령") as ToolResponse;
+  }
+
+  const searchTypeNames: Record<AiLawSearchType, string> = {
+    "0": "법령조문",
+    "1": "법령 별표·서식",
+    "2": "행정규칙 조문",
+    "3": "행정규칙 별표·서식",
+  };
+  const searchTypeName = searchTypeNames[searchType];
+
+  const displayCount = args.lawTypes ? items.length : totalCount;
+  const filterNote = args.lawTypes ? ` [필터: ${args.lawTypes.join(', ')}]` : '';
+  let output = `지능형 법령검색 결과 (${searchTypeName}, ${displayCount}건${filterNote}):\n\n`;
+
+  for (const item of items) {
+    if (searchType === "0" || searchType === "2") {
+      output += `${item.법령명 || item.행정규칙명}\n`;
+      if (item.조문번호) {
+        output += `   제${item.조문번호}조`;
+        if (item.조문가지번호 && item.조문가지번호 !== "00") {
+          output += `의${parseInt(item.조문가지번호)}`;
+        }
+        if (item.조문제목) {
+          output += ` (${item.조문제목})`;
+        }
+        output += `\n`;
+      }
+      if (item.조문내용) {
+        const content = item.조문내용.replace(/<[^>]*>/g, "").substring(0, 200);
+        output += `   ${content}${item.조문내용.length > 200 ? "..." : ""}\n`;
+      }
+      output += `   시행: ${formatDateDot(item.시행일자)} | ${item.소관부처명 || item.발령기관명 || ""}\n`;
+    } else {
+      output += `${item.법령명 || item.행정규칙명}\n`;
+      output += `   [${item.별표서식구분명 || "별표/서식"}] ${item.별표서식제목 || ""}\n`;
+      output += `   시행: ${formatDateDot(item.시행일자)}\n`;
+    }
+    output += `\n`;
+  }
+
+  return {
+    content: [{
+      type: "text",
+      text: truncateResponse(output)
+    }]
+  };
+}
+
+export async function searchAiLawStructured(
+  apiClient: LawApiClient,
+  args: SearchAiLawInput
+): Promise<SearchAiLawStructuredResult> {
+  const searchType = args.search || "0";
+
+  const xmlText = await apiClient.fetchApi({
+    endpoint: "lawSearch.do",
+    target: "aiSearch",
+    extraParams: {
+      query: args.query,
+      search: searchType,
+      display: (args.display || 20).toString(),
+      page: (args.page || 1).toString(),
+    },
+    apiKey: args.apiKey,
+  });
+
+  const { totalCount, items, articleSignals } = parseAiLawSearchXml(xmlText, searchType);
+
+  return {
+    response: renderAiLawSearchResult(args, searchType, totalCount, items),
+    articleSignals,
+  };
+}
+
 export async function searchAiLaw(
   apiClient: LawApiClient,
   args: SearchAiLawInput
 ): Promise<{ content: Array<{ type: string, text: string }>, isError?: boolean }> {
   try {
-    const searchType = args.search || "0";
-
-    const xmlText = await apiClient.fetchApi({
-      endpoint: "lawSearch.do",
-      target: "aiSearch",
-      extraParams: {
-        query: args.query,
-        search: searchType,
-        display: (args.display || 20).toString(),
-        page: (args.page || 1).toString(),
-      },
-      apiKey: args.apiKey,
-    });
-    // searchType에 따라 itemTag 결정
-    const itemTagMap: Record<string, string> = {
-      "0": "법령조문", "1": "법령별표서식", "2": "행정규칙조문", "3": "행정규칙별표서식"
-    };
-    const itemTag = itemTagMap[searchType] || "법령조문";
-
-    // parseSearchXML 사용 (rootTag: aiSearch, totalTag: 검색결과개수)
-    const { totalCnt: totalCount, items: parsedItems } = parseSearchXML(
-      xmlText, "aiSearch", itemTag,
-      (itemContent) => {
-        const extractField = (tag: string) => sharedExtractTag(itemContent, tag);
-        const item: any = { 시행일자: extractField("시행일자") };
-
-        if (searchType === "0") {
-          item.법령ID = extractField("법령ID");
-          item.법령명 = extractField("법령명");
-          item.법령종류명 = extractField("법령종류명");
-          item.소관부처명 = extractField("소관부처명");
-          item.조문번호 = extractField("조문번호");
-          item.조문가지번호 = extractField("조문가지번호");
-          item.조문제목 = extractField("조문제목");
-          item.조문내용 = extractField("조문내용");
-        } else if (searchType === "1") {
-          item.법령ID = extractField("법령ID");
-          item.법령명 = extractField("법령명");
-          item.별표서식번호 = extractField("별표서식번호");
-          item.별표서식제목 = extractField("별표서식제목");
-          item.별표서식구분명 = extractField("별표서식구분명");
-        } else if (searchType === "2") {
-          item.행정규칙ID = extractField("행정규칙ID");
-          item.행정규칙명 = extractField("행정규칙명");
-          item.발령기관명 = extractField("발령기관명");
-          item.조문번호 = extractField("조문번호");
-          item.조문가지번호 = extractField("조문가지번호");
-          item.조문제목 = extractField("조문제목");
-          item.조문내용 = extractField("조문내용");
-        } else {
-          item.행정규칙ID = extractField("행정규칙ID");
-          item.행정규칙명 = extractField("행정규칙명");
-          item.별표서식번호 = extractField("별표서식번호");
-          item.별표서식제목 = extractField("별표서식제목");
-          item.별표서식구분명 = extractField("별표서식구분명");
-        }
-        return item;
-      },
-      { totalTag: "검색결과개수" }
-    );
-
-    let items = parsedItems as any[];
-
-    // lawTypes 필터 적용 (클라이언트 사이드)
-    if (args.lawTypes && args.lawTypes.length > 0 && items.length > 0) {
-      const typeSet = new Set(args.lawTypes.map((t: string) => t.trim()));
-      items = items.filter((item: any) => {
-        const kind = item.법령종류명 || "";
-        return typeSet.has(kind);
-      });
-    }
-
-    if (totalCount === 0 || items.length === 0) {
-      return noResultHint(args.query || "", "생활법령")
-    }
-
-    const searchTypeNames: Record<string, string> = {
-      "0": "법령조문",
-      "1": "법령 별표·서식",
-      "2": "행정규칙 조문",
-      "3": "행정규칙 별표·서식",
-    };
-    const searchTypeName = searchTypeNames[searchType];
-
-    const displayCount = args.lawTypes ? items.length : totalCount;
-    const filterNote = args.lawTypes ? ` [필터: ${args.lawTypes.join(', ')}]` : '';
-    let output = `지능형 법령검색 결과 (${searchTypeName}, ${displayCount}건${filterNote}):\n\n`;
-
-    for (const item of items) {
-      if (searchType === "0" || searchType === "2") {
-        // 조문 검색 결과
-        output += `${item.법령명 || item.행정규칙명}\n`;
-        if (item.조문번호) {
-          output += `   제${item.조문번호}조`;
-          if (item.조문가지번호 && item.조문가지번호 !== "00") {
-            output += `의${parseInt(item.조문가지번호)}`;
-          }
-          if (item.조문제목) {
-            output += ` (${item.조문제목})`;
-          }
-          output += `\n`;
-        }
-        if (item.조문내용) {
-          const content = item.조문내용.replace(/<[^>]*>/g, "").substring(0, 200);
-          output += `   ${content}${item.조문내용.length > 200 ? "..." : ""}\n`;
-        }
-        output += `   시행: ${formatDateDot(item.시행일자)} | ${item.소관부처명 || item.발령기관명 || ""}\n`;
-      } else {
-        // 별표·서식 검색 결과
-        output += `${item.법령명 || item.행정규칙명}\n`;
-        output += `   [${item.별표서식구분명 || "별표/서식"}] ${item.별표서식제목 || ""}\n`;
-        output += `   시행: ${formatDateDot(item.시행일자)}\n`;
-      }
-      output += `\n`;
-    }
-
-    // 후속 도구 안내 제거 (LLM이 이미 도구 목록을 알고 있음)
-
-    return {
-      content: [{
-        type: "text",
-        text: truncateResponse(output)
-      }]
-    };
+    return (await searchAiLawStructured(apiClient, args)).response;
   } catch (error) {
     return formatToolError(error, "search_ai_law");
   }

--- a/src/tools/precedents.ts
+++ b/src/tools/precedents.ts
@@ -12,6 +12,8 @@ import {
 
 export const searchPrecedentsSchema = z.object({
   query: z.string().optional().describe("검색 키워드 (예: '자동차', '담보권')"),
+  search: z.number().int().min(1).max(2).optional()
+    .describe("검색범위: 1=판례명 검색(기본), 2=본문검색"),
   court: z.string().optional().describe("법원명 필터 (예: '대법원', '서울고등법원')"),
   caseNumber: z.string().optional().describe("사건번호 (예: '2009느합133')"),
   display: z.number().min(1).max(100).default(20).describe("결과 수 (기본:20, 최대:100)"),
@@ -35,6 +37,7 @@ export async function searchPrecedents(
       page: (args.page || 1).toString(),
     };
     if (args.query) extraParams.query = args.query;
+    if (args.search) extraParams.search = args.search.toString();
     if (args.court) extraParams.curt = args.court;
     if (args.caseNumber) extraParams.nb = args.caseNumber;
     if (args.sort) extraParams.sort = args.sort;

--- a/test/test-chain-full-research-precedent-retry.cjs
+++ b/test/test-chain-full-research-precedent-retry.cjs
@@ -124,6 +124,31 @@ function genericContractAiLawXml() {
   ].join("")
 }
 
+function definitionFirstAiLawXml() {
+  return [
+    "<aiSearch>",
+    "<검색결과개수>2</검색결과개수>",
+    "<page>1</page>",
+    "<법령조문>",
+    "<법령명>콘텐츠산업 진흥법</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0002</조문번호>",
+    "<조문제목>정의</조문제목>",
+    "<조문내용>제2조(정의) 이 법에서 사용하는 용어의 뜻은 다음과 같다.</조문내용>",
+    "<시행일자>20251001</시행일자>",
+    "</법령조문>",
+    "<법령조문>",
+    "<법령명>전자상거래 등에서의 소비자보호에 관한 법률</법령명>",
+    "<법령종류명>법률</법령종류명>",
+    "<조문번호>0017</조문번호>",
+    "<조문제목>청약철회등</조문제목>",
+    "<조문내용>통신판매업자와 재화등의 구매에 관한 계약을 체결한 소비자는 기간 이내에 청약철회등을 할 수 있다.</조문내용>",
+    "<시행일자>20260120</시행일자>",
+    "</법령조문>",
+    "</aiSearch>",
+  ].join("")
+}
+
 function extendedIssueAiLawXml() {
   return [
     "<aiSearch>",
@@ -149,14 +174,14 @@ function noPrecedentXml() {
   return "<PrecSearch><totalCnt>0</totalCnt><page>1</page></PrecSearch>"
 }
 
-function precedentXml() {
+function precedentXml(caseName = "중고거래 물품대금 반환 사건", id = "12345") {
   return [
     "<PrecSearch>",
     "<totalCnt>1</totalCnt>",
     "<page>1</page>",
     "<prec>",
-    "<판례일련번호>12345</판례일련번호>",
-    "<사건명>중고거래 물품대금 반환 사건</사건명>",
+    `<판례일련번호>${id}</판례일련번호>`,
+    `<사건명>${caseName}</사건명>`,
     "<사건번호>2024가단12345</사건번호>",
     "<법원명>서울중앙지방법원</법원명>",
     "<선고일자>20240101</선고일자>",
@@ -167,11 +192,45 @@ function precedentXml() {
   ].join("")
 }
 
-function makeApiClient({ succeedOnQuery, aiLawXml = noAiLawXml(), lawXml = noLawXml() }) {
+function precedentDetailJson({
+  caseName = "판례",
+  issue = "테스트 판시사항",
+  summary = "테스트 판결요지",
+  body = "테스트 판례 내용",
+} = {}) {
+  return JSON.stringify({
+    PrecService: {
+      사건명: caseName,
+      사건번호: "2024가단12345",
+      법원명: "서울중앙지방법원",
+      선고일자: "20240101",
+      판결유형: "판결",
+      판시사항: issue,
+      판결요지: summary,
+      참조조문: "",
+      참조판례: "",
+      판례내용: body,
+    },
+  })
+}
+
+function makeApiClient({
+  succeedOnQuery,
+  succeedOnRequest,
+  precedentResponseForRequest,
+  precedentDetailCaseName,
+  precedentDetailIssue,
+  precedentDetailSummary,
+  precedentDetailBody,
+  aiLawXml = noAiLawXml(),
+  lawXml = noLawXml(),
+}) {
   const precedentQueries = []
+  const precedentRequests = []
   const lawTextRequests = []
   return {
     precedentQueries,
+    precedentRequests,
     lawTextRequests,
     async searchLaw() {
       return lawXml
@@ -183,10 +242,26 @@ function makeApiClient({ succeedOnQuery, aiLawXml = noAiLawXml(), lawXml = noLaw
     async fetchApi(request) {
       if (request.target === "aiSearch") return aiLawXml
       if (request.target === "expc") return noInterpretationXml()
+      if (request.endpoint === "lawService.do" && request.target === "prec") {
+        return precedentDetailJson({
+          caseName: precedentDetailCaseName || "청약철회 관련 사건",
+          issue: precedentDetailIssue,
+          summary: precedentDetailSummary,
+          body: precedentDetailBody || "전자상거래 청약철회등과 환불 의무에 관한 판례 내용",
+        })
+      }
       if (request.target === "prec") {
         const query = String(request.extraParams?.query || "")
+        const search = String(request.extraParams?.search || "1")
         precedentQueries.push(query)
-        return query === succeedOnQuery ? precedentXml() : noPrecedentXml()
+        precedentRequests.push({ query, search })
+        if (precedentResponseForRequest) {
+          return precedentResponseForRequest({ query, search })
+        }
+        const matched = succeedOnRequest
+          ? succeedOnRequest({ query, search })
+          : query === succeedOnQuery
+        return matched ? precedentXml(`${query} 중고거래 물품대금 반환 사건`) : noPrecedentXml()
       }
       throw new Error(`unexpected target: ${request.target}`)
     },
@@ -245,6 +320,80 @@ async function testIgnoresGenericContractPhrase(chainFullResearch) {
   assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
   assert.ok(!apiClient.precedentQueries.includes("관한 계약"), apiClient.precedentQueries.join(", "))
   assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+}
+
+async function testDoesNotRetryGenericDefinitionBeforeSpecificTitle(chainFullResearch) {
+  const apiClient = makeApiClient({
+    succeedOnQuery: "청약철회",
+    aiLawXml: definitionFirstAiLawXml(),
+  })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
+  assert.ok(!apiClient.precedentQueries.includes("정의"), apiClient.precedentQueries.join(", "))
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+}
+
+async function testUsesBodySearchForSpacedTerminalVariant(chainFullResearch) {
+  const apiClient = makeApiClient({
+    aiLawXml: definitionFirstAiLawXml(),
+    succeedOnRequest: ({ query, search }) => query === "청약철회 등" && search === "2",
+  })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.ok(
+    apiClient.precedentRequests.some((request) => request.query === "청약철회 등" && request.search === "2"),
+    JSON.stringify(apiClient.precedentRequests)
+  )
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회 등\""), text)
+}
+
+async function testBodySearchValidationUsesFullDetailText(chainFullResearch) {
+  const middleOnlyBody = `${"가".repeat(900)} 청약철회등 ${"나".repeat(1000)}`
+  const apiClient = makeApiClient({
+    aiLawXml: definitionFirstAiLawXml(),
+    precedentDetailCaseName: "온라인 거래 환불 사건",
+    precedentDetailIssue: "온라인 거래 관련 쟁점",
+    precedentDetailSummary: "소비자 환불 관련 판단",
+    precedentDetailBody: middleOnlyBody,
+    precedentResponseForRequest: ({ query, search }) => {
+      if (query === QUERY) return noPrecedentXml()
+      if (query === "청약철회 등" && search === "2") return precedentXml("온라인 거래 환불 사건")
+      return noPrecedentXml()
+    },
+  })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.ok(
+    apiClient.precedentRequests.some((request) => request.query === "청약철회 등" && request.search === "2"),
+    JSON.stringify(apiClient.precedentRequests)
+  )
+  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회 등\""), text)
+}
+
+async function testRejectsUnrelatedNonEmptyRetryResult(chainFullResearch) {
+  const apiClient = makeApiClient({
+    aiLawXml: genericContractAiLawXml(),
+    precedentDetailCaseName: "자동차 보험금 사건",
+    precedentDetailBody: "자동차 보험금 지급 기준에 관한 판례 내용",
+    precedentResponseForRequest: ({ query }) => {
+      if (query === QUERY) return noPrecedentXml()
+      return precedentXml("자동차 보험금 사건")
+    },
+  })
+
+  const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
+  const text = result.content?.[0]?.text || ""
+
+  assert.ok(apiClient.precedentQueries.length > 2, apiClient.precedentQueries.join(", "))
+  assert.ok(!text.includes("판례 1차 검색 실패 후 재검색어"), text)
+  assert.ok(!text.includes("자동차 보험금 사건"), text)
 }
 
 async function testUsesAiLawArticleTitleCandidate(chainFullResearch) {
@@ -323,6 +472,10 @@ async function main() {
   await testRetriesSuggestedKeywordAfterRawPrecedentFailure(chainFullResearch)
   await testIgnoresQuotedLawNameFragments(chainFullResearch)
   await testIgnoresGenericContractPhrase(chainFullResearch)
+  await testDoesNotRetryGenericDefinitionBeforeSpecificTitle(chainFullResearch)
+  await testUsesBodySearchForSpacedTerminalVariant(chainFullResearch)
+  await testBodySearchValidationUsesFullDetailText(chainFullResearch)
+  await testRejectsUnrelatedNonEmptyRetryResult(chainFullResearch)
   await testUsesAiLawArticleTitleCandidate(chainFullResearch)
   await testUsesLowConfidenceLawTextFallback(chainFullResearch)
   await testKeepsExplicitLawText(chainFullResearch)

--- a/test/test-compact-query-planner.cjs
+++ b/test/test-compact-query-planner.cjs
@@ -16,6 +16,23 @@ const AI_LAW_TEXT = [
   "   시행: 2026.01.01 | 고용노동부",
 ].join("\n")
 
+const AI_LAW_ARTICLES = [
+  {
+    lawName: "콘텐츠산업 진흥법",
+    articleNo: "0002",
+    articleTitle: "정의",
+    articleContent: "이 법에서 사용하는 용어의 뜻은 다음과 같다.",
+    sourceIndex: 0,
+  },
+  {
+    lawName: "전자상거래 등에서의 소비자보호에 관한 법률",
+    articleNo: "0017",
+    articleTitle: "청약철회등",
+    articleContent: "제17조(청약철회등) 소비자는 통신판매업자와 재화등의 구매에 관한 계약을 체결한 경우 청약철회등을 할 수 있다.",
+    sourceIndex: 1,
+  },
+]
+
 async function testUsesStructuredAiLawSignals() {
   const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
 
@@ -31,6 +48,55 @@ async function testUsesStructuredAiLawSignals() {
   assert.ok(candidates.includes("고용정책 기본법 취업기회의 균등한 보장"), candidates.join(", "))
 }
 
+async function testUsesRawAiLawArticleSignalsBeforeFormattedText() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "중고거래로 옷을 팔았는데 환불해달라고 합니다",
+    aiLawArticles: AI_LAW_ARTICLES,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.ok(queries.includes("청약철회등"), queries.join(", "))
+  assert.ok(queries.includes("청약철회"), queries.join(", "))
+  assert.ok(queries.includes("청약철회 등"), queries.join(", "))
+  assert.ok(queries.includes("전자상거래 등에서의 소비자보호에 관한 법률 청약철회"), queries.join(", "))
+  assert.ok(!queries.includes("정의"), queries.join(", "))
+
+  const rawTitle = candidates.find((candidate) => candidate.query === "청약철회등")
+  const titleSearch = candidates.find((candidate) => candidate.query === "청약철회")
+  const bodySearch = candidates.find((candidate) => candidate.query === "청약철회 등")
+
+  assert.strictEqual(rawTitle.semanticAnchor, "청약철회등")
+  assert.strictEqual(rawTitle.variantKind, "raw")
+  assert.strictEqual(titleSearch.search, 1)
+  assert.strictEqual(titleSearch.variantKind, "terminal_function_word_removed")
+  assert.strictEqual(titleSearch.requiresResultValidation, true)
+  assert.strictEqual(bodySearch.search, 2)
+  assert.strictEqual(bodySearch.variantKind, "terminal_function_word_spaced")
+  assert.strictEqual(bodySearch.requiresResultValidation, true)
+}
+
+async function testDoesNotDestructivelyStripEqualityTitle() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "직장에서 성평등 침해를 받았습니다",
+    aiLawArticles: [{
+      lawName: "양성평등기본법",
+      articleNo: "0003",
+      articleTitle: "성평등",
+      articleContent: "성평등은 정치ㆍ경제ㆍ사회ㆍ문화의 모든 영역에서 평등한 책임과 권리를 공유하는 것을 말한다.",
+      sourceIndex: 0,
+    }],
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.ok(candidates.includes("성평등"), candidates.join(", "))
+  assert.ok(!candidates.includes("성평"), candidates.join(", "))
+}
+
 async function testDoesNotExtractBodySuffixKeywords() {
   const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
 
@@ -41,6 +107,25 @@ async function testDoesNotExtractBodySuffixKeywords() {
   }).map((candidate) => candidate.query)
 
   assert.ok(!candidates.includes("고용 차별"), candidates.join(", "))
+}
+
+async function testDoesNotCreateCandidatesFromArticleContentReferences() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "소비자가 환불을 요구합니다",
+    aiLawArticles: [{
+      lawName: "콘텐츠산업 진흥법",
+      articleNo: "0027",
+      articleTitle: "표시의무",
+      articleContent: "콘텐츠제작자는 「전자상거래 등에서의 소비자보호에 관한 법률」 제17조(청약철회등)에 따라 표시하여야 한다.",
+      sourceIndex: 0,
+    }],
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.ok(candidates.includes("표시의무"), candidates.join(", "))
+  assert.ok(!candidates.includes("청약철회"), candidates.join(", "))
 }
 
 async function testUsesRetrySuggestionsAndRouterCandidates() {
@@ -79,7 +164,10 @@ async function testFiltersWeakCandidates() {
 
 async function main() {
   await testUsesStructuredAiLawSignals()
+  await testUsesRawAiLawArticleSignalsBeforeFormattedText()
+  await testDoesNotDestructivelyStripEqualityTitle()
   await testDoesNotExtractBodySuffixKeywords()
+  await testDoesNotCreateCandidatesFromArticleContentReferences()
   await testUsesRetrySuggestionsAndRouterCandidates()
   await testFiltersWeakCandidates()
   console.log("compact query planner tests passed")

--- a/test/test-precedent-search-scope.cjs
+++ b/test/test-precedent-search-scope.cjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+function noPrecedentXml() {
+  return "<PrecSearch><totalCnt>0</totalCnt><page>1</page></PrecSearch>"
+}
+
+async function testPassesSearchScope() {
+  const { searchPrecedents } = await import("../build/tools/precedents.js")
+  const calls = []
+  const apiClient = {
+    async fetchApi(request) {
+      calls.push(request)
+      return noPrecedentXml()
+    },
+  }
+
+  await searchPrecedents(apiClient, {
+    query: "청약철회 등",
+    search: 2,
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(calls[0].extraParams.search, "2")
+}
+
+async function testKeepsDefaultSearchScopeImplicit() {
+  const { searchPrecedents } = await import("../build/tools/precedents.js")
+  const calls = []
+  const apiClient = {
+    async fetchApi(request) {
+      calls.push(request)
+      return noPrecedentXml()
+    },
+  }
+
+  await searchPrecedents(apiClient, {
+    query: "청약철회",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.ok(!("search" in calls[0].extraParams), JSON.stringify(calls[0].extraParams))
+}
+
+async function main() {
+  await testPassesSearchScope()
+  await testKeepsDefaultSearchScopeImplicit()
+  console.log("precedent search scope tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## 요약

이 PR은 PR #37에서 추가된 Open WebUI MCP chain 검색→상세조회 흐름의 **판례 재검색 성공률을 높이는 2차 개선**입니다.

핵심은 판례 검색어를 더 많이 찍어내는 것이 아니라, `search_ai_law`가 받은 원본 XML의 `<조문제목>` 신호를 텍스트 정리 전에 보존해서 판례 검색 후보를 더 정확하게 만드는 것입니다. 기존 chain 내부 구조와 deterministic scoring 흐름은 유지하고, 실패한 판례 검색을 보완하는 지점만 좁게 고친 surgical change입니다.

## 왜 필요한가

기존 흐름은 `chain_full_research`에서 원질문으로 판례를 먼저 검색하고, 실패하면 aiSearch 결과에서 짧은 키워드를 뽑아 재검색했습니다. 하지만 이 과정에서 조문 제목/내용이 이미 포맷된 텍스트로 섞인 뒤 다시 추출되어 다음 문제가 있었습니다.

- 원본 `<조문제목>`을 안정적으로 쓰지 못해 핵심 법률 개념을 놓칠 수 있음
- `청약철회등` 같은 붙여쓴 제목을 무리하게 줄이면 `성평등 -> 성평` 같은 오추출 위험이 있음
- `정의` 같은 일반 제목이 구체적 조문 제목보다 앞서는 경우가 있음
- 판례명 검색과 본문 검색의 검색 특성이 다른데 모든 후보를 같은 방식으로 다룸

## 무엇이 달라졌나

- `search_ai_law` 내부에 raw XML 구조 파싱 경로를 추가해 `<조문제목>`, `<조문내용>`, 법령명, 조문번호를 포맷 전 단계에서 보존했습니다.
- 판례 재검색 후보는 `<조문제목>` 중심으로 만들고, `<조문내용>`은 후보 생성에 직접 쓰지 않고 기존 deterministic scoring/evidence 보정에만 사용합니다.
- `청약철회등`을 원문 anchor로 보존하면서, 검색 API 특성에 맞게 다음 후보를 나눠 시도합니다.
  - 제목 검색용: `청약철회` (`search=1`)
  - 본문 검색용: `청약철회 등` (`search=2`)
- `search_precedents`에 법제처 판례목록 조회 API의 `search` 파라미터를 선택적으로 전달할 수 있게 했습니다. 기본값은 기존처럼 판례명 검색입니다.
- lossy 후보나 본문검색 후보는 검색 결과를 그대로 믿지 않고, 기존 판례 상세조회/텍스트 검증 경로로 관련성을 확인합니다.
- 리뷰 피드백을 반영해 `search=2` 본문검색 검증은 축약된 판례내용이 아니라 full 상세 텍스트로 확인합니다. 본문 중간에 검색어가 있을 때 false negative가 나지 않게 하기 위한 보정입니다.

## 2차 개선의 의미

이번 개선은 “필터 규칙을 계속 늘리는 방식”이 아니라, 검색 실패의 원인을 API 입력 구조에 더 가깝게 옮겨 해결한 작업입니다.

예를 들어 소비자보호 관련 질문에서 aiSearch raw 조문 제목이 `<조문제목>청약철회등</조문제목>`이라면, 기존 방식은 이 값을 포맷된 텍스트에서 다시 찾거나 무리하게 정규화해야 했습니다. 이제는 raw 제목을 semantic anchor로 보존하고, 판례명 검색과 본문 검색에 맞는 후보를 따로 생성합니다. 그래서 제목 검색이 실패해도 본문 검색 `청약철회 등` 후보로 한 번 더 탐색할 수 있습니다.

동시에 `성평등`처럼 `등`이 단어 일부인 경우에는 `성평` 같은 잘못된 후보를 만들지 않도록, 원문 제목을 파괴하지 않고 lossy variant는 검증이 필요한 후보로만 취급합니다. 즉 성공률을 높이되, 잘못된 판례를 끌어올 위험은 상세 검증 단계로 줄이는 방향입니다.

## 변경 범위

- `src/tools/life-law.ts`
  - aiSearch raw XML article signal 파싱 추가
- `src/tools/compact-query-planner.ts`
  - 조문 제목 기반 후보 생성 및 search scope-aware variant 추가
- `src/tools/precedents.ts`
  - 판례목록 조회 `search=1|2` 선택 파라미터 추가
- `src/tools/chains.ts`
  - 판례 재검색 후보 실행 및 관련성 검증 보강
- 테스트 추가/보강
  - compact query planner
  - chain_full_research 판례 재검색
  - precedent search scope 전달

## 검증

- `npm run build`
- `node test\test-chain-full-research-precedent-retry.cjs`
- `node test\test-compact-query-planner.cjs`
- `node test\test-precedent-search-scope.cjs`
- `node test\test-chain-search-detail-integration.cjs`
- `node test\test-search-detail-chain.cjs`
