### PR TITLE
fix: 법제처 API 요청에 Referer 헤더 추가 (사용자 정보 검증 실패 / 모든 검색 NOT_FOUND 해결)

### DIFF
--- a/src/lib/fetch-with-retry.ts
+++ b/src/lib/fetch-with-retry.ts
@@ -47,6 +47,21 @@ const DEFAULT_USER_AGENT =
   process.env.LAW_USER_AGENT ||
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
+// 법제처 OPEN API는 Referer 헤더가 없으면 OC 키가 유효해도
+// "사용자 정보 검증에 실패하였습니다 (정확한 서버장비의 IP주소 및 도메인주소를 등록해 주세요)"
+// XML을 반환한다. 메시지는 IP/도메인 등록 문제로 오인되기 쉬우나 실제 원인은 Referer 누락이다.
+// (브라우저 UA만으로는 통과하지 못하고 Referer가 결정적). LAW_REFERER 환경변수로 override 가능.
+const DEFAULT_REFERER = process.env.LAW_REFERER || "https://www.law.go.kr/"
+
+// Referer를 붙일 법제처 계열 호스트 판별 (그 외 호스트엔 주입하지 않음).
+function isLawGoKrHost(targetUrl: string): boolean {
+  try {
+    return /(^|\.)law\.go\.kr$/i.test(new URL(targetUrl).hostname)
+  } catch {
+    return false
+  }
+}
+
 /**
  * Fetch with automatic retry and timeout
  */
@@ -70,6 +85,7 @@ export async function fetchWithRetry(
 
     const headers = new Headers(fetchOptions.headers)
     if (!headers.has("user-agent")) headers.set("user-agent", DEFAULT_USER_AGENT)
+    if (!headers.has("referer") && isLawGoKrHost(url)) headers.set("referer", DEFAULT_REFERER)
 
     try {
       const response = await fetch(url, {


### PR DESCRIPTION
## 문제

유효한 OC 키를 설정했는데도 **모든 법령/판례 검색이 `[NOT_FOUND]`로 실패**하는 현상이 있습니다 (`민법` 같은 기본 법령조차).

추적해 보니, 법제처 OPEN API는 요청에 **`Referer` 헤더가 없으면** OC 키가 유효하더라도 다음 XML을 반환합니다:

```xml
<Response>
  <result>사용자 정보 검증에 실패하였습니다.</result>
  <msg>OPEN API 호출 시 사용자 검증을 위하여 정확한 서버장비의 IP주소 및 도메인주소를 등록해 주세요.</msg>
</Response>
```

상위 파서가 이를 `[NOT_FOUND]`로 변환하면서, 사용자 입장에서는 "키는 승인됐는데 아무것도 안 나오는" 상태가 됩니다.

## 진단

에러 메시지(`IP주소 및 도메인주소를 등록해 주세요`)가 IP 화이트리스트 문제로 오인되기 쉽지만 — CHANGELOG에도 유사한 User-Agent 함정 사례가 기록돼 있습니다 — 헤더를 하나씩 격리해 테스트한 결과 **실제 결정 요인은 `Referer`** 였습니다 (동일 OC 키·동일 IP 기준):

| User-Agent | Referer | 결과 |
|---|---|---|
| 브라우저 UA | ❌ 없음 | ❌ 사용자 정보 검증 실패 |
| ❌ 없음 | `https://www.law.go.kr/` | ✅ 정상 JSON 응답 |

현재 `fetchWithRetry`는 브라우저 User-Agent는 주입하지만 Referer는 보내지 않아, 환경에 따라 위 검증에 걸립니다.

## 변경 내용

`src/lib/fetch-with-retry.ts`에서, 요청 호스트가 `law.go.kr` 계열일 때만 기본 `Referer` 헤더를 주입합니다.

- 호출자가 이미 `referer`를 지정했거나, `law.go.kr` 이외 호스트(예: 국세청 `taxlaw.nts.go.kr`)인 경우엔 **건드리지 않습니다.**
- 기존 `LAW_USER_AGENT` 패턴과 동일하게 **`LAW_REFERER` 환경변수로 override** 가능합니다.

```ts
if (!headers.has("referer") && isLawGoKrHost(url)) headers.set("referer", DEFAULT_REFERER)
```

## 검증

- `npm run build` (tsc) 통과
- 패치된 빌드로 `fetchWithRetry`를 통해 `도시 및 주거환경정비법` 검색 → **MST 276973 정상 반환** 확인 (패치 전: "사용자 정보 검증 실패")
