### PR TITLE
fix: 판례 검색 fallback 및 상세조회 연결 강화

### DIFF
--- a/docs/PRECEDENT-SEARCH-GUIDELINES.md
+++ b/docs/PRECEDENT-SEARCH-GUIDELINES.md
@@ -1,0 +1,165 @@
+# 판례 검색 반영 지침
+
+이 문서는 판례 검색과 판례 본문조회 동작을 수정할 때 확인해야 할 호출 경로, 현재 구현 정책, 검증 항목을 정리한다.
+
+대상 독자는 `korean-law-mcp`의 판례 검색, 통합 결정례 검색, 체인 도구를 수정하는 개발자다.
+
+## 핵심 원칙
+
+- 판례 검색은 여러 경로에서 호출된다. 직접 도구 호출, 통합 결정례 검색, 체인 도구, 보조 분석 도구가 같은 구현을 공유하거나 우회할 수 있으므로 한 경로만 보고 동작을 판단하지 않는다.
+- 검색 도구와 상세조회 도구는 별도 도구다. MCP `tools/call`은 요청된 handler만 실행하며, 자연어 라우터나 search-detail chain을 자동 실행하지 않는다.
+- 새 호출 경로에서는 렌더링된 텍스트에서 ID를 다시 파싱하는 방식보다 구조화된 hit 목록을 우선 사용한다.
+- 기존 호환성을 위해 `search_precedents` 출력의 `[id] 제목` 형식은 유지한다. 기존 search-detail chain은 이 형식에서 상세조회 ID를 추출한다.
+- 판례 검색 결과가 없을 때 LLM이 판례를 추측하지 않도록 실패 상태와 재시도 힌트를 명확히 렌더링한다.
+- 특정 조문 영향도처럼 정확한 역방향 탐색이 중요한 경로는 자동 fallback을 끄고 원 검색어 그대로 조회한다.
+
+## 현재 구현 요약
+
+이번 판례 검색 강화는 공통 구조화 검색 core를 중심으로 동작한다.
+
+- `src/tools/precedent-search-core.ts`
+  - `searchPrecedentsStructured()`가 판례 목록 검색의 공통 진입점이다.
+  - 반환값은 `StructuredPrecedentSearchResult`이며 `hits`, `attempts`, `fallbackUsed`, `successfulAttempt`를 포함한다.
+  - 1차 검색은 명시 사건번호가 있으면 `caseNumber`, 아니면 원문 `query`로 수행한다.
+  - 기본 fallback 정책은 `"full"`이다. 제목 검색 실패 시 본문검색(`search=2`)을 먼저 시도하고, 이후 compact query 후보를 시도한다.
+  - `fallbackPolicy: "body"`는 본문검색까지만 허용한다.
+  - `fallbackPolicy: "none"`은 보정 검색을 하지 않는다.
+  - `maxFallbackAttempts`로 compact query 후보 개수를 제한한다. 기본값은 5다.
+  - 날짜 조건이 있으면 표시되는 hit 기준으로 `totalCount`를 맞춘다.
+  - 날짜 조건 때문에 결과가 모두 걸러졌지만 원 raw hit가 있으면 `date_relaxed` fallback으로 요청 기간 밖 결과를 표시할 수 있다.
+
+- `src/tools/compact-query-planner.ts`
+  - 원 자연어 질의, 사건번호, 문서 hint, query-router 후보, AI 법령검색의 조문 신호를 compact query 후보로 만든다.
+  - 세금·건설 등 도메인 축과 사실 축을 분리해 `법리축 + 사실축` 후보를 우선 만든다.
+  - 후보마다 `source`, `score`, `variantKind`, `requiresResultValidation`, `validationTermGroups`를 보존한다.
+  - 결과 검증이 필요한 후보는 상세조회 검증 경로로 이어질 수 있다.
+
+- `src/tools/precedent-evidence.ts`
+  - `validatePrecedentSearchResult()`가 fallback 결과의 목록 메타데이터와 필요 시 상세 본문을 검증한다.
+  - `fetchPrecedentEvidence()`가 구조화 hit의 상위 판례를 `getPrecedentText()`로 조회해 증거 텍스트를 만든다.
+  - 상세조회 기본 개수는 2건이고, 최대 5건으로 제한한다.
+
+- `src/tools/precedents.ts`
+  - `searchPrecedents()`는 구조화 core를 호출한 뒤 `renderPrecedentSearchResult()`로 기존 텍스트 형식으로 렌더링한다.
+  - 결과가 없으면 `[NOT_FOUND]`와 재시도 힌트를 포함하고 `isError`를 설정한다.
+  - 결과가 있으면 `[id] 제목`, 사건번호, 법원, 선고일, 판결유형, 링크를 유지한다.
+  - fallback이 사용되면 성공한 보정 시도와 검색 범위를 출력한다.
+
+## 주요 호출 경로
+
+### MCP 도구 등록과 직접 실행
+
+- `src/tool-registry.ts`
+- `search_precedents`와 `get_precedent_text`는 별도 도구로 등록된다.
+- v3 exposed profile에서는 직접 노출 도구가 제한된다. 현재 직접 노출 도구는 `V3_EXPOSED`에 있는 17개이며, `search_precedents`와 `get_precedent_text`는 직접 노출되지 않는다.
+- `execute_tool`, `search_decisions`, `get_decision_text`를 통한 우회 호출도 고려한다.
+
+### 직접 판례 검색과 본문조회
+
+- `src/tools/precedents.ts`
+- `searchPrecedents`는 `searchPrecedentsStructured()`를 호출하고, 사람이 읽을 수 있는 텍스트로 렌더링한다.
+- `getPrecedentText`는 판례 일련번호로 본문을 조회한다.
+- 판례 JSON 본문이 비어 있거나 파싱이 실패할 수 있으므로 HTML fallback 경로를 유지한다.
+
+### 구조화 판례 검색 core
+
+- `src/tools/precedent-search-core.ts`
+- 긴 자연어 질의는 원문 검색, 본문검색, 축약 검색어 후보 순서로 보정할 수 있다.
+- 사건번호가 명시된 경우 사건번호 검색을 우선한다.
+- 날짜 범위가 있는 검색은 렌더링되는 hit 수와 `totalCount`가 어긋나지 않도록 주의한다.
+- 날짜 범위 밖 결과를 fallback으로 보여줄 때는 `outOfRequestedDateRange` 표시를 유지한다.
+- 조문 단위 역방향 탐색처럼 원 검색어 의미가 좁은 경로에서는 `fallbackPolicy: "none"`을 사용한다.
+
+### 검색 결과 검증과 상세 증거
+
+- `src/tools/precedent-evidence.ts`
+- fallback 후보가 넓은 검색어일수록 결과 검증이 필요하다.
+- 검증은 목록 텍스트만 보지 말고 필요하면 상위 상세 본문까지 확인한다.
+- 상세조회는 응답 크기와 외부 API 부하를 고려해 기본 상한을 둔다.
+- 검증용 상세조회는 기본적으로 1건만 확인한다.
+
+### 자연어 라우팅
+
+- `src/lib/query-router.ts`
+- 자연어 라우터는 검색어를 일부 정규화하고 도구 실행 계획을 만들 수 있지만, raw MCP tool call에는 자동 적용되지 않는다.
+- 구조화 core는 `routeQuery(input.query)` 결과를 context로 받을 수 있다. 라우터 개선만으로 직접 도구 호출, 통합 검색, 체인 도구의 동작이 모두 개선된다고 가정하지 않는다.
+
+### search-detail chain
+
+- `src/lib/tool-chain-config.ts`
+- `src/tools/search-detail-chain.ts`
+- 기존 chain은 렌더링된 검색 결과에서 bracketed ID를 추출한다.
+- `search_precedents` 렌더링 형식을 변경할 때는 chain 상세조회 테스트를 함께 수정하고 검증한다.
+
+### 체인 도구
+
+- `src/tools/chains.ts`
+- `chain_full_research`는 AI 법령검색, 법령 검색, 해석례 검색을 먼저 수행하고, AI 조문 신호와 query-router 결과를 context로 넘겨 판례를 구조화 검색한다.
+- `chain_dispute_prep`은 판례 검색과 상세 증거 조회를 `searchPrecedentsForChain()` 경로로 처리한다.
+- `chain_document_review`는 `analyze_document` 출력의 `검색:` hint를 최대 5개까지 추출하고, 각 hint에 대해 구조화 판례 검색을 수행한다.
+- `chain_document_review`의 판례 fallback 후보는 hint별 최대 3개로 제한한다.
+- 체인 도구는 `fetchPrecedentEvidence()`로 상위 2건의 상세 증거를 붙인다.
+- 체인 도구 안에서만 동작하는 임시 fallback을 늘리기보다 공통 core로 모으는 것을 우선한다.
+- 문서 검토 체인의 검색 hint 형식 변경은 후속 판례 검색에 영향을 줄 수 있다.
+
+### 통합 결정례 검색
+
+- `src/tools/unified-decisions.ts`
+- `search_decisions`는 `domain="precedent"`일 때 기본적으로 기존 `searchPrecedents()` handler를 호출한다.
+- `options.includeText`가 `true` 또는 `"true"`이면 `searchPrecedentDecisionsWithText()` 경로로 들어간다.
+- `includeText` 경로는 구조화 판례 검색 결과 뒤에 `fetchPrecedentEvidence()` 상세 증거를 붙인다.
+- `options.detailLimit`은 숫자 또는 숫자 문자열을 받을 수 있고, 실제 상세조회 개수는 `precedent-evidence`의 상한을 따른다.
+- `get_decision_text`는 여전히 `domain="precedent"`와 검색 결과 ID를 받아 `getPrecedentText()`로 상세 본문을 조회한다.
+
+### 조문 기반 보조 도구
+
+- `src/tools/article-with-precedents.ts`
+- `get_article_with_precedents`는 조문 본문에서 법령명을 추출해 `${lawName} ${jo}`로 관련 판례를 검색한다.
+- 이 경로는 `fallbackPolicy: "none"`을 사용한다. 조문 영향 검색에서 의미가 넓어지는 보정 검색을 하지 않는다.
+
+- `src/tools/impact-map.ts`
+- `impact_map`은 `${공식법령명} ${조문번호}`를 기준으로 판례, 해석례, 행정심판례, 헌재 결정례, 자치법규를 역방향 탐색한다.
+- 판례 검색은 `searchPrecedentsStructured()`를 쓰지만 `fallbackPolicy: "none"`으로 제한한다.
+
+### 다른 판례 호출자
+
+- `src/tools/similar-precedents.ts`
+- `src/tools/precedent-summary.ts`
+- `src/tools/precedent-keywords.ts`
+- `src/tools/scenarios/*`
+
+판례 검색 core나 렌더링을 바꾸면 위 호출자들이 검색 결과 없음, 상세조회 실패, ID 형식, 축약 응답을 어떻게 처리하는지 확인한다.
+
+## 구현 체크리스트
+
+판례 검색 변경 PR은 아래 항목을 확인한다.
+
+- 직접 `search_precedents` 호출과 `get_precedent_text` 호출이 각각 정상 동작한다.
+- `search_decisions`의 `domain="precedent"` 경로가 기존 호환성을 유지한다.
+- `search_decisions(domain="precedent", options.includeText=true)` 경로가 목록과 상세 증거를 함께 반환한다.
+- `options.detailLimit`은 기본값, 비정상 값, 상한 초과 값을 확인한다.
+- 체인 도구는 판례 목록과 상세 증거를 모두 안정적으로 렌더링한다.
+- bracketed ID 형식이 깨지지 않는다.
+- 검색 결과 없음은 `isError`와 명시적 실패 문구를 반환한다.
+- 날짜 필터 결과의 `totalCount`와 실제 표시 hit 수가 맞다.
+- fallback 후보가 원 질의와 멀어질 때 결과 검증을 수행한다.
+- 조문 기반 경로는 `fallbackPolicy: "none"`을 유지한다.
+- 외부 API 오류와 본문 누락은 도구 오류로 처리하고 판례 내용을 생성하지 않는다.
+- transport나 MCP endpoint를 바꾸기 전에 실제 transport 문제가 재현되는지 확인한다.
+
+## 권장 검증
+
+변경 범위에 따라 아래 테스트를 실행한다.
+
+```bash
+npm run build
+node test/test-precedent-search-core.cjs
+node test/test-precedent-evidence.cjs
+node test/test-chain-search-detail-integration.cjs
+node test/test-chain-full-research-precedent-retry.cjs
+node test/test-compact-query-planner.cjs
+node test/test-precedent-search-scope.cjs
+node test/test-search-decisions-precedent-include-text.cjs
+```
+
+외부 API 키나 네트워크가 필요한 live 테스트는 환경 조건을 PR 본문에 명시한다.

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -673,7 +673,7 @@ export const allTools: McpTool[] = [
   // === 통합 도구 (v3) ===
   {
     name: "search_decisions",
-    description: "[통합검색] 18개 도메인(판례·해석례·헌재·행심·조세심판·관세·국세청·공정위·개인정보위·노동위·권익위·소청심사·학칙·공사공단·공공기관·조약·영문법령) 통합 검색. domain으로 선택. 세무 관련 국세청 직접 회신 해석은 domain='nts'.",
+    description: "[통합검색] 18개 도메인(판례·해석례·헌재·행심·조세심판·관세·국세청·공정위·개인정보위·노동위·권익위·소청심사·학칙·공사공단·공공기관·조약·영문법령) 통합 검색. domain으로 선택. 판례 본문까지 필요하면 domain='precedent', options.includeText=true, options.detailLimit=N. 세무 관련 국세청 직접 회신 해석은 domain='nts'.",
     schema: SearchDecisionsSchema,
     handler: searchDecisions
   },

--- a/src/tools/article-with-precedents.ts
+++ b/src/tools/article-with-precedents.ts
@@ -5,7 +5,8 @@
 import { z } from "zod"
 import type { LawApiClient } from "../lib/api-client.js"
 import { getLawText, GetLawTextInput } from "./law-text.js"
-import { searchPrecedents } from "./precedents.js"
+import { renderPrecedentSearchResult } from "./precedents.js"
+import { searchPrecedentsStructured } from "./precedent-search-core.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { formatToolError } from "../lib/errors.js"
 
@@ -53,15 +54,17 @@ export async function getArticleWithPrecedents(
     const precedentQuery = `${lawName} ${input.jo}`
 
     try {
-      const precedentResult = await searchPrecedents(apiClient, {
+      const precedentResult = await searchPrecedentsStructured(apiClient, {
         query: precedentQuery,
         display: 5,
         page: 1,
         apiKey: input.apiKey
+      }, {
+        fallbackPolicy: "none",
       })
 
-      if (!precedentResult.isError) {
-        const precedentText = precedentResult.content[0].text
+      if (precedentResult.hits.length > 0) {
+        const precedentText = renderPrecedentSearchResult(precedentResult)
 
         // 판례 결과가 있으면 추가
         if (precedentText && !precedentText.includes("검색 결과가 없습니다")) {

--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -21,7 +21,7 @@ import type { ScenarioType, ScenarioContext } from "./scenarios/index.js"
 import { analyzeDocument } from "./document-analysis.js"
 import { getThreeTier } from "./three-tier.js"
 import { getBatchArticles } from "./batch-articles.js"
-import { getPrecedentText, searchPrecedents } from "./precedents.js"
+import { renderPrecedentSearchResult, searchPrecedents, type SearchPrecedentsInput } from "./precedents.js"
 import { summarizePrecedent } from "./precedent-summary.js"
 import { searchInterpretations } from "./interpretations.js"
 import { searchAdminAppeals } from "./admin-appeals.js"
@@ -34,8 +34,13 @@ import { searchAiLaw, searchAiLawStructured, type AiLawArticleSignal, type Searc
 import { getLawText } from "./law-text.js"
 import { searchTaxTribunalDecisions } from "./tax-tribunal-decisions.js"
 import { searchNlrcDecisions, searchPipcDecisions } from "./committee-decisions.js"
-import { fetchSearchDetailChain, fetchCombinedSearchDetailChain } from "./search-detail-chain.js"
-import { buildCompactLegalQueries, type CompactQueryCandidate } from "./compact-query-planner.js"
+import { fetchSearchDetailChain } from "./search-detail-chain.js"
+import {
+  searchPrecedentsStructured,
+  type PrecedentSearchContext,
+  type StructuredPrecedentSearchResult,
+} from "./precedent-search-core.js"
+import { fetchPrecedentEvidence, validatePrecedentSearchResult } from "./precedent-evidence.js"
 
 // ========================================
 // Types
@@ -55,7 +60,43 @@ type ExpansionType = "annex_fee" | "annex_form" | "annex_table" | "precedent" | 
 // Helpers
 // ========================================
 
-const PRECEDENT_RETRY_LIMIT = 5
+const PRECEDENT_FALLBACK_LIMIT = 5
+
+function emptyStructuredPrecedentResult(args: SearchPrecedentsInput): StructuredPrecedentSearchResult {
+  return {
+    originalArgs: args,
+    totalCount: 0,
+    page: args.page || 1,
+    hits: [],
+    attempts: [],
+    fallbackUsed: false,
+  }
+}
+
+function errorCallResult(error: unknown, toolName: string): CallResult {
+  const response = formatToolError(error, toolName)
+  return {
+    text: response.content?.[0]?.text || (error instanceof Error ? error.message : String(error)),
+    isError: true,
+  }
+}
+
+async function safeSearchPrecedentsStructured(
+  apiClient: LawApiClient,
+  args: SearchPrecedentsInput,
+  context: PrecedentSearchContext = {}
+): Promise<{ result: StructuredPrecedentSearchResult; error?: CallResult }> {
+  try {
+    return {
+      result: await searchPrecedentsStructured(apiClient, args, context),
+    }
+  } catch (error) {
+    return {
+      result: emptyStructuredPrecedentResult(args),
+      error: errorCallResult(error, "search_precedents"),
+    }
+  }
+}
 
 async function callTool(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -172,113 +213,71 @@ function selectLawTextSource(laws: LawInfo[], query: string): { reliableLaws: La
   return { reliableLaws, textLaw: laws[0], lowConfidence: laws.length > 0 }
 }
 
-function normalizeRelevanceText(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/\s+/g, "")
-    .replace(/[^\p{L}\p{N}]+/gu, "")
-}
-
-function candidateRelevanceTerms(candidate: CompactQueryCandidate): string[] {
-  return Array.from(new Set([candidate.query, candidate.semanticAnchor]
-    .filter((term): term is string => typeof term === "string" && normalizeRelevanceText(term).length >= 2)))
-}
-
-function textContainsCandidateTerm(text: string, candidate: CompactQueryCandidate): boolean {
-  const haystack = normalizeRelevanceText(text)
-  return candidateRelevanceTerms(candidate)
-    .some(term => haystack.includes(normalizeRelevanceText(term)))
-}
-
-function extractPrecedentCaseLines(searchText: string): string[] {
-  return searchText
-    .split("\n")
-    .filter(line => /^\[\d+\]\s+/.test(line.trim()))
-}
-
-function extractFirstPrecedentId(searchText: string): string | undefined {
-  for (const line of searchText.split("\n")) {
-    const match = line.trim().match(/^\[(\d+)\]\s+/)
-    if (match?.[1]) return match[1]
-  }
-  return undefined
-}
-
-async function validateRetryPrecedentResult(
+async function searchPrecedentsForChain(
   apiClient: LawApiClient,
-  candidate: CompactQueryCandidate,
-  result: CallResult,
-  apiKey?: string
-): Promise<boolean> {
-  const caseLines = extractPrecedentCaseLines(result.text)
-  if (caseLines.some(line => textContainsCandidateTerm(line, candidate))) {
-    return true
+  input: { query: string; display: number; apiKey?: string },
+  context: PrecedentSearchContext = {},
+  detailLimit = 2
+): Promise<{ structuredResult: StructuredPrecedentSearchResult; searchResult: CallResult; detailResult: CallResult | null }> {
+  const args: SearchPrecedentsInput = {
+    query: input.query,
+    display: input.display,
+    page: 1,
+    apiKey: input.apiKey,
   }
-
-  if (candidate.search !== 2 && !candidate.requiresResultValidation) {
-    return false
-  }
-
-  const id = extractFirstPrecedentId(result.text)
-  if (!id) return false
-
-  const detail = await callTool(getPrecedentText, apiClient, {
-    id,
-    full: candidate.search === 2,
-    apiKey,
-  })
-  if (isSearchFailure(detail) || !detail.text.trim()) return false
-
-  return textContainsCandidateTerm(detail.text, candidate)
-}
-
-function formatRetryCandidate(candidate: CompactQueryCandidate): string {
-  return candidate.search === 2 ? `"${candidate.query}"(본문검색)` : `"${candidate.query}"`
-}
-
-async function retryPrecedentsIfNeeded(
-  apiClient: LawApiClient,
-  input: { query: string; apiKey?: string },
-  precedentResult: CallResult,
-  aiLawResult?: CallResult
-): Promise<CallResult> {
-  if (!isSearchFailure(precedentResult)) return precedentResult
-
-  const route = routeQuery(input.query)
-  const candidates = buildCompactLegalQueries({
-    originalQuery: input.query,
-    aiLawArticles: aiLawResult?.aiLawArticles,
-    aiLawText: aiLawResult?.text,
-    route,
-    failedSearchText: precedentResult.text,
-    max: PRECEDENT_RETRY_LIMIT,
+  const { result: search, error } = await safeSearchPrecedentsStructured(apiClient, args, {
+    ...context,
+    maxFallbackAttempts: context.maxFallbackAttempts ?? PRECEDENT_FALLBACK_LIMIT,
+    validateResult: validation => validatePrecedentSearchResult(apiClient, validation, { apiKey: input.apiKey }),
   })
 
-  if (candidates.length === 0) return precedentResult
-
-  for (const candidate of candidates) {
-    const retried = await callTool(searchPrecedents, apiClient, {
-      query: candidate.query,
-      search: candidate.search,
-      display: 5,
-      apiKey: input.apiKey,
-    })
-    if (!isSearchFailure(retried) && retried.text.trim() && await validateRetryPrecedentResult(apiClient, candidate, retried, input.apiKey)) {
-      return {
-        text: `판례 1차 검색 실패 후 재검색어 "${candidate.query}"로 조회했습니다.\n\n${retried.text}`,
-        isError: false,
-      }
+  if (error) {
+    return {
+      structuredResult: search,
+      searchResult: error,
+      detailResult: null,
     }
   }
 
+  const searchResult: CallResult = {
+    text: renderPrecedentSearchResult(search),
+    isError: search.hits.length === 0,
+  }
+  const evidence = await fetchPrecedentEvidence(apiClient, search, {
+    apiKey: input.apiKey,
+    detailLimit,
+    full: false,
+  })
+
   return {
-    text: [
-      precedentResult.text,
-      "",
-      `재검색 시도(최대 ${PRECEDENT_RETRY_LIMIT}회): ${candidates.map(formatRetryCandidate).join(", ")}`,
-      "모든 재검색에서 판례 검색 결과가 없습니다.",
-    ].join("\n"),
-    isError: true,
+    structuredResult: search,
+    searchResult,
+    detailResult: evidence ? { text: evidence.text, isError: evidence.isError } : null,
+  }
+}
+
+function combineStructuredPrecedentResults(
+  results: StructuredPrecedentSearchResult[]
+): StructuredPrecedentSearchResult | null {
+  const nonEmpty = results.filter(result => result.hits.length > 0)
+  if (nonEmpty.length === 0) return null
+
+  const seen = new Set<string>()
+  const hits = nonEmpty.flatMap(result => result.hits)
+    .filter(hit => {
+      if (seen.has(hit.id)) return false
+      seen.add(hit.id)
+      return true
+    })
+
+  return {
+    originalArgs: nonEmpty[0].originalArgs,
+    totalCount: hits.length,
+    page: 1,
+    hits,
+    attempts: results.flatMap(result => result.attempts),
+    fallbackUsed: results.some(result => result.fallbackUsed),
+    successfulAttempt: nonEmpty[0].successfulAttempt,
   }
 }
 
@@ -444,9 +443,13 @@ export async function chainDisputePrep(
   try {
     const parts = [`═══ 쟁송 대비: ${input.query} ═══`]
 
-    // Step 1: 판례 + 행정심판 (병렬)
+    // Step 1: 판례 + 행정심판 (병렬). 판례는 구조화 hit 기반 상세조회까지 같은 경로에서 처리한다.
+    const precedentPromise = searchPrecedentsForChain(
+      apiClient,
+      { query: input.query, display: 8, apiKey: input.apiKey },
+      { route: routeQuery(input.query) }
+    )
     const parallel: Promise<CallResult>[] = [
-      callTool(searchPrecedents, apiClient, { query: input.query, display: 8, apiKey: input.apiKey }),
       callTool(searchAdminAppeals, apiClient, { query: input.query, display: 8, apiKey: input.apiKey }),
     ]
 
@@ -460,25 +463,27 @@ export async function chainDisputePrep(
       parallel.push(callTool(searchPipcDecisions, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }))
     }
 
-    const results = await Promise.all(parallel)
-
-    parts.push(secOrSkip("대법원 판례", results[0]))
-    parts.push(secOrSkip("행정심판례", results[1]))
-
-    const [precDetail, appealDetail] = await Promise.all([
-      fetchSearchDetailChain(apiClient, "search_precedents", results[0], { apiKey: input.apiKey }),
-      fetchSearchDetailChain(apiClient, "search_admin_appeals", results[1], { apiKey: input.apiKey }),
+    const [precedentBundle, results] = await Promise.all([
+      precedentPromise,
+      Promise.all(parallel),
     ])
-    if (precDetail) parts.push(secOrSkip("대법원 판례 상세", precDetail))
+
+    parts.push(secOrSkip("대법원 판례", precedentBundle.searchResult))
+    parts.push(secOrSkip("행정심판례", results[0]))
+
+    const [appealDetail] = await Promise.all([
+      fetchSearchDetailChain(apiClient, "search_admin_appeals", results[0], { apiKey: input.apiKey }),
+    ])
+    if (precedentBundle.detailResult) parts.push(secOrSkip("대법원 판례 상세", precedentBundle.detailResult))
     if (appealDetail) parts.push(secOrSkip("행정심판례 상세", appealDetail))
 
-    if (results[2]) {
+    if (results[1]) {
       const domainNames: Record<string, string> = {
         tax: "조세심판원 결정",
         labor: "중앙노동위 결정",
         privacy: "개인정보위 결정",
       }
-      parts.push(secOrSkip(domainNames[domain] || "전문 결정례", results[2]))
+      parts.push(secOrSkip(domainNames[domain] || "전문 결정례", results[1]))
 
       const domainSearchTools: Record<string, string> = {
         tax: "search_tax_tribunal_decisions",
@@ -487,7 +492,7 @@ export async function chainDisputePrep(
       }
       const domainSearchTool = domainSearchTools[domain]
       if (domainSearchTool) {
-        const domainDetail = await fetchSearchDetailChain(apiClient, domainSearchTool, results[2], { apiKey: input.apiKey })
+        const domainDetail = await fetchSearchDetailChain(apiClient, domainSearchTool, results[1], { apiKey: input.apiKey })
         if (domainDetail) parts.push(secOrSkip(`${domainNames[domain] || "전문 결정례"} 상세`, domainDetail))
       }
     }
@@ -662,20 +667,27 @@ export async function chainFullResearch(
   try {
     const parts = [`═══ 종합 리서치: ${input.query} ═══`]
 
-    // Step 1: AI 검색 + 법령 검색 + 판례/해석 모두 병렬
+    // Step 1: AI 검색 + 법령 검색 + 해석례를 병렬 실행하고, 판례는 AI 구조화 신호를 받은 뒤 공통 core로 검색한다.
     // findLaws를 안전하게 래핑 (throw 시 Promise.all 전체 reject 방지)
     const safeFindLaws = async (): Promise<LawInfo[]> => {
       try { return await findLaws(apiClient, input.query, input.apiKey, 2) }
       catch { return [] }
     }
-    const [aiResult, rawLawsResult, precResult, interpResult] = await Promise.all([
+    const [aiResult, rawLawsResult, interpResult] = await Promise.all([
       callAiLaw(apiClient, { query: input.query, search: "0", display: 10, page: 1, apiKey: input.apiKey }),
       safeFindLaws(),
-      callTool(searchPrecedents, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
       callTool(searchInterpretations, apiClient, { query: input.query, display: 5, apiKey: input.apiKey }),
     ])
     const { reliableLaws: lawsResult, textLaw, lowConfidence } = selectLawTextSource(rawLawsResult, input.query)
-    const finalPrecResult = await retryPrecedentsIfNeeded(apiClient, input, precResult, aiResult)
+    const precedentBundle = await searchPrecedentsForChain(
+      apiClient,
+      { query: input.query, display: 5, apiKey: input.apiKey },
+      {
+        aiLawArticles: aiResult.aiLawArticles,
+        route: routeQuery(input.query),
+        maxFallbackAttempts: PRECEDENT_FALLBACK_LIMIT,
+      }
+    )
 
     parts.push(secOrSkip("AI 법령검색 결과", aiResult))
 
@@ -686,14 +698,13 @@ export async function chainFullResearch(
       parts.push(secOrSkip(`${textLaw.lawName} 본문${confidenceSuffix}`, lawText))
     }
 
-    parts.push(secOrSkip("관련 판례", finalPrecResult))
+    parts.push(secOrSkip("관련 판례", precedentBundle.searchResult))
     parts.push(secOrSkip("법령 해석례", interpResult))
 
-    const [precDetail, interpDetail] = await Promise.all([
-      fetchSearchDetailChain(apiClient, "search_precedents", finalPrecResult, { apiKey: input.apiKey }),
+    const [interpDetail] = await Promise.all([
       fetchSearchDetailChain(apiClient, "search_interpretations", interpResult, { apiKey: input.apiKey }),
     ])
-    if (precDetail) parts.push(secOrSkip("관련 판례 상세", precDetail))
+    if (precedentBundle.detailResult) parts.push(secOrSkip("관련 판례 상세", precedentBundle.detailResult))
     if (interpDetail) parts.push(secOrSkip("법령 해석례 상세", interpDetail))
 
     // 키워드 확장
@@ -831,48 +842,66 @@ export async function chainDocumentReview(
     // 중복 제거 후 최대 5개 힌트로 제한
     const uniqueHints = [...new Set(searchHints)].slice(0, 5)
 
-    const searchPromises: Promise<CallResult>[] = []
-    for (const hint of uniqueHints) {
-      searchPromises.push(
-        callTool(searchPrecedents, apiClient, { query: hint, display: 3, apiKey: input.apiKey })
-      )
-    }
-    // AI 법령 검색도 상위 3개 힌트로 병렬 실행
-    const lawHints = uniqueHints.slice(0, 3)
-    for (const hint of lawHints) {
-      searchPromises.push(
-        callTool(searchAiLaw, apiClient, { query: hint, display: 3, apiKey: input.apiKey })
-      )
-    }
+    const precedentSearches = await Promise.all(
+      uniqueHints.map(hint => safeSearchPrecedentsStructured(apiClient, {
+        query: hint,
+        display: 3,
+        page: 1,
+        apiKey: input.apiKey,
+      }, {
+        documentHints: [hint],
+        maxFallbackAttempts: 3,
+        validateResult: validation => validatePrecedentSearchResult(apiClient, validation, { apiKey: input.apiKey }),
+      }))
+    )
+    const precedentResults = precedentSearches.map(search => search.result)
 
-    const searchResults = await Promise.all(searchPromises)
+    // AI 법령 검색은 상위 3개 힌트로 병렬 실행
+    const lawHints = uniqueHints.slice(0, 3)
+    const lawResults = await Promise.all(
+      lawHints.map(hint => callTool(searchAiLaw, apiClient, { query: hint, display: 3, apiKey: input.apiKey }))
+    )
 
     // 판례 결과 합산
     const precTexts: string[] = []
     for (let i = 0; i < uniqueHints.length; i++) {
-      const r = searchResults[i]
-      if (!r.isError && r.text.trim()) {
-        precTexts.push(`[${uniqueHints[i]}]\n${r.text}`)
+      const r = precedentResults[i]
+      if (r.hits.length > 0) {
+        precTexts.push(`[${uniqueHints[i]}]\n${renderPrecedentSearchResult(r)}`)
       }
     }
     if (precTexts.length > 0) {
       parts.push(sec("관련 판례", precTexts.join("\n\n")))
     }
+    const precedentErrors = precedentSearches
+      .map((search, index) => search.error ? `[${uniqueHints[index]}]\n${search.error.text}` : "")
+      .filter(text => text.trim())
+    if (precedentErrors.length > 0) {
+      parts.push(secOrSkip("판례 검색 실패", {
+        text: precedentErrors.join("\n\n"),
+        isError: true,
+      }))
+    }
 
-    const precedentDetail = await fetchCombinedSearchDetailChain(
-      apiClient,
-      "search_precedents",
-      searchResults.slice(0, uniqueHints.length),
-      { apiKey: input.apiKey }
-    )
-    if (precedentDetail) {
-      parts.push(secOrSkip("관련 판례 상세", precedentDetail))
+    const combinedPrecedents = combineStructuredPrecedentResults(precedentResults)
+    if (combinedPrecedents) {
+      const precedentEvidence = await fetchPrecedentEvidence(apiClient, combinedPrecedents, {
+        apiKey: input.apiKey,
+        detailLimit: 2,
+        full: false,
+      })
+      if (precedentEvidence) {
+        parts.push(secOrSkip("관련 판례 상세", {
+          text: precedentEvidence.text,
+          isError: precedentEvidence.isError,
+        }))
+      }
     }
 
     // 법령 결과 합산
     const lawTexts: string[] = []
     for (let i = 0; i < lawHints.length; i++) {
-      const r = searchResults[uniqueHints.length + i]
+      const r = lawResults[i]
       if (!r.isError && r.text.trim()) {
         lawTexts.push(`[${lawHints[i]}]\n${r.text}`)
       }

--- a/src/tools/compact-query-planner.ts
+++ b/src/tools/compact-query-planner.ts
@@ -1,19 +1,25 @@
 import type { AiLawArticleSignal } from "./life-law.js"
 
 export type CompactQuerySource =
+  | "case_number"
+  | "original_query"
+  | "original_keyword"
+  | "document_hint"
   | "ai_law_article_title"
   | "ai_law_law_article_title"
-  | "search_retry_hint"
   | "router"
 
 export type PrecedentSearchScope = 1 | 2
 
 export type CompactQueryVariantKind =
+  | "case_number"
+  | "original_query"
+  | "original_keyword"
+  | "document_hint"
   | "raw"
   | "terminal_function_word_removed"
   | "terminal_function_word_spaced"
   | "law_title"
-  | "retry_hint"
   | "router"
 
 export interface CompactQueryCandidate {
@@ -23,6 +29,7 @@ export interface CompactQueryCandidate {
   reason: string
   search: PrecedentSearchScope
   semanticAnchor?: string
+  validationTermGroups?: string[][]
   variantKind: CompactQueryVariantKind
   requiresResultValidation: boolean
 }
@@ -34,10 +41,11 @@ interface RouteLike {
 
 export interface CompactQueryInput {
   originalQuery: string
+  includeOriginal?: boolean
+  caseNumber?: string
+  documentHints?: string[]
   aiLawArticles?: AiLawArticleSignal[]
-  aiLawText?: string
   route?: RouteLike
-  failedSearchText?: string
   max?: number
 }
 
@@ -55,6 +63,83 @@ const LOW_INFORMATION_ARTICLE_TITLES = new Set([
 ])
 
 const MIN_AI_ARTICLE_SCORE = 90
+const CASE_CODE_PATTERN = "(?:고합|고단|고정|고약|구합|구단|구|누|두|헌가|헌나|헌다|헌라|헌마|헌바|헌사|카합|카단|카기|회합|회단|[가나다라마바사아자차카타파하]|고|노|도|모|보|로|초)"
+const COURT_CASE_RE = new RegExp(`(?:19|20)\\d{2}\\s*${CASE_CODE_PATTERN}\\s*\\d{1,8}`, "u")
+const LEGAL_CORE_KEYWORDS = new Set([
+  "근로", "종속", "지휘", "감독", "출퇴근", "전속", "도급", "위장", "프리랜서",
+  "임금", "퇴직금", "해고", "부당", "계약", "고용", "근로자", "사용자",
+  "법률", "법령", "조문", "항", "호", "목",
+  "판례", "결정", "심판", "재판", "소송", "처분", "취소", "환급",
+  "재산", "분할", "상속", "혼인", "이혼",
+  "손해", "배상", "위약", "불법",
+  "개인정보", "보호", "유출", "침해",
+  "세금", "소득세", "양도소득세", "부가세", "법인세", "국세", "조세", "과세", "부과처분",
+  "건설", "건설공사", "공사", "도급", "하도급", "발주자", "발주처", "원청", "원사업자", "수급인", "하수급인",
+])
+const TAX_DOMAIN_KEYWORDS = new Set([
+  "양도소득세", "소득세", "부가세", "법인세", "국세", "조세", "세금", "과세", "부과처분",
+])
+const CONSTRUCTION_LEGAL_AXIS_KEYWORDS = new Set([
+  "건설", "건설공사", "공사", "도급", "하도급", "발주자", "발주처", "원청", "원사업자", "수급인", "하수급인",
+])
+const GENERIC_LEGAL_ACTION_KEYWORDS = new Set([
+  "처분", "취소", "환급", "결정", "심판", "재판", "소송",
+])
+const FACT_AXIS_PATTERNS = [
+  "사기행위", "사기", "부정한 행위", "부정한행위", "허위계약서", "허위", "명의위장", "조세회피",
+  "하자보수", "하자담보책임", "부실시공", "미시공", "하자",
+  "지체상금", "지연손해금", "공사지연", "공기지연", "공기연장",
+  "설계변경", "추가공사", "변경공사", "준공", "사용승인",
+  "공사비", "공사대금", "기성금", "기성고", "추가공사비", "선급금",
+  "대금직불", "계약금액조정", "물가변동", "감리",
+  "프리랜서", "외주", "도급", "위탁", "계약직",
+  "출퇴근", "근무시간", "근무장소", "통제",
+  "전속", "배타적", "겸직",
+  "월급", "고정급", "수수료", "성과급",
+  "해고당함", "퇴직", "사직",
+  "임금체불", "미지급", "체불",
+  "이혼", "재산", "부동산",
+  "자녀", "양육", "친권",
+]
+const FACT_AXIS_SYNONYMS: Record<string, string[]> = {
+  "사기": ["사기행위", "부정한 행위", "허위"],
+  "허위": ["허위계약서", "사기", "부정한 행위"],
+  "하자보수": ["하자", "하자담보책임", "부실시공"],
+  "하자": ["하자보수", "하자담보책임", "부실시공"],
+  "지체상금": ["지연손해금", "공사지연", "공기지연", "공기연장"],
+  "공기지연": ["지체상금", "지연손해금", "공사지연", "공기연장"],
+  "설계변경": ["추가공사", "변경공사", "공사대금"],
+  "공사비": ["공사대금", "기성금", "추가공사비"],
+  "공사대금": ["공사비", "기성금", "추가공사비"],
+}
+const ORIGINAL_QUERY_STOPWORDS = new Set([
+  "판례",
+  "판결",
+  "결정",
+  "사례",
+  "관련",
+  "대한",
+  "관한",
+  "찾아줘",
+  "찾아주세요",
+  "알려줘",
+  "알려주세요",
+  "검색",
+  "조회",
+  "의무",
+  "가능",
+  "가능한",
+  "가능한가",
+  "가능한가요",
+  "가능여부",
+  "여부",
+  "절차",
+  "방법",
+  "행위",
+  "의해",
+  "부과",
+  "부과된",
+])
 
 function normalizeArticleTitle(title: string): string {
   return normalizeCandidate(title)
@@ -64,6 +149,29 @@ function normalizeCandidate(query: string): string {
   return query
     .replace(/[“”]/g, "\"")
     .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function normalizeCaseNumber(caseNumber: string): string {
+  return normalizeCandidate(caseNumber).replace(/\s+/g, "")
+}
+
+function extractCaseNumber(text: string): string | null {
+  const match = normalizeCandidate(text).match(COURT_CASE_RE)
+  return match ? normalizeCaseNumber(match[0]) : null
+}
+
+function normalizeOriginalPrecedentQuery(query: string): string {
+  return normalizeCandidate(query)
+    .replace(/<[^>]*>/g, " ")
+    .replace(COURT_CASE_RE, match => normalizeCaseNumber(match))
+    .replace(/(대법원|고등법원|지방법원|가정법원|행정법원|특허법원|법원)/g, " ")
+    .replace(/(판례|판결|결정례|결정|사례)/g, " ")
+    .replace(/(찾아주세요|찾아줘요|찾아줘|알려주세요|알려줘요|알려줘|검색해주세요|검색해줘요|검색해줘|조회해주세요|조회해줘요|조회해줘|검색|조회)/g, " ")
+    .replace(/\s+[을를이가은는]\s+/g, " ")
+    .replace(/\s+[을를이가은는]$/g, "")
+    .replace(/\b(관련|대한|관한)\b/g, " ")
     .replace(/\s+/g, " ")
     .trim()
 }
@@ -94,6 +202,172 @@ function supportTokens(text: string): string[] {
       .map(token => token.replace(/(에서|에게|으로|로서|로써|부터|까지|합니다|해달라고)$/u, ""))
       .filter(token => token.length >= 2)
   ))
+}
+
+function normalizeAxisToken(token: string): string {
+  return token
+    .replace(/[?？!.,]/g, "")
+    .replace(/(에서|에게|으로|로서|로써|부터|까지|입니다|합니다|했다|한다|해요)$/u, "")
+    .replace(/(되었는지|되었는가|되는지|되는가|인가요|인지요|인가|인지)$/u, "")
+    .replace(/(가|이|은|는|을|를|에|의|와|과)$/u, "")
+    .replace(/된$/u, "")
+    .trim()
+}
+
+function extractedOriginalKeywords(originalQuery: string): string[] {
+  const words = normalizeOriginalPrecedentQuery(originalQuery)
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .split(/\s+/)
+    .map(normalizeAxisToken)
+    .filter(token => token.length >= 2 && !ORIGINAL_QUERY_STOPWORDS.has(token))
+
+  const core: string[] = []
+  const other: string[] = []
+  const seen = new Set<string>()
+
+  for (const word of words) {
+    if (seen.has(word)) continue
+    seen.add(word)
+    const isCore = Array.from(LEGAL_CORE_KEYWORDS).some(keyword => keyword.includes(word) || word.includes(keyword))
+    if (isCore) core.push(word)
+    else other.push(word)
+  }
+
+  return [...core, ...other]
+}
+
+interface QueryAxes {
+  legalAxis: string[]
+  factAxis: string[]
+  legalValidationTerms: string[]
+  factValidationTerms: string[]
+}
+
+function addUnique(out: string[], value: string): void {
+  const normalized = normalizeCandidate(value)
+  if (normalized && !out.includes(normalized)) out.push(normalized)
+}
+
+function compactAxisTerm(term: string): string {
+  return term.replace(/\s+/g, "")
+}
+
+function canonicalFactAxisTerm(term: string): string {
+  const compact = compactAxisTerm(term)
+  for (const axis of Object.keys(FACT_AXIS_SYNONYMS)) {
+    if (compactAxisTerm(axis) === compact) return axis
+  }
+  for (const [axis, synonyms] of Object.entries(FACT_AXIS_SYNONYMS)) {
+    if (synonyms.some(synonym => compactAxisTerm(synonym) === compact)) return axis
+  }
+  return term
+}
+
+function addLegalAxisForKeyword(axes: QueryAxes, keyword: string): void {
+  const compact = keyword.replace(/\s+/g, "")
+  if (!compact) return
+
+  if (TAX_DOMAIN_KEYWORDS.has(compact) || compact.includes("소득세") || compact.includes("조세") || compact.includes("과세")) {
+    if (compact.includes("양도소득세")) addUnique(axes.legalAxis, "양도소득세")
+    if (compact.includes("소득세")) addUnique(axes.legalAxis, "소득세")
+    if (compact.includes("조세")) addUnique(axes.legalAxis, "조세")
+    if (compact.includes("과세")) addUnique(axes.legalAxis, "과세")
+    addUnique(axes.legalValidationTerms, "양도소득세")
+    addUnique(axes.legalValidationTerms, "소득세")
+    addUnique(axes.legalValidationTerms, "조세")
+    addUnique(axes.legalValidationTerms, "과세")
+    return
+  }
+
+  if (CONSTRUCTION_LEGAL_AXIS_KEYWORDS.has(compact)) {
+    if (compact.includes("건설공사")) addUnique(axes.legalAxis, "건설공사")
+    else if (compact.includes("건설")) addUnique(axes.legalAxis, "건설공사")
+    else addUnique(axes.legalAxis, compact)
+    addUnique(axes.legalValidationTerms, "건설공사")
+    addUnique(axes.legalValidationTerms, "건설")
+    addUnique(axes.legalValidationTerms, "공사")
+    addUnique(axes.legalValidationTerms, "도급")
+    addUnique(axes.legalValidationTerms, "하도급")
+    return
+  }
+
+  if (LEGAL_CORE_KEYWORDS.has(compact) || /[가-힣]+법$/u.test(compact)) {
+    addUnique(axes.legalAxis, compact)
+    addUnique(axes.legalValidationTerms, compact)
+  }
+}
+
+function addFactAxisForKeyword(axes: QueryAxes, keyword: string): void {
+  const compact = keyword.replace(/\s+/g, "")
+  if (!compact) return
+  if (CONSTRUCTION_LEGAL_AXIS_KEYWORDS.has(compact)) return
+
+  const matchedPattern = FACT_AXIS_PATTERNS.find(pattern => {
+    const normalizedPattern = pattern.replace(/\s+/g, "")
+    return compact.includes(normalizedPattern) || normalizedPattern.includes(compact)
+  })
+
+  if (matchedPattern) {
+    const fact = matchedPattern.replace(/\s+/g, "")
+    const canonicalFact = canonicalFactAxisTerm(fact)
+    addUnique(axes.factAxis, canonicalFact)
+    addUnique(axes.factValidationTerms, fact)
+    addUnique(axes.factValidationTerms, canonicalFact)
+    for (const synonym of FACT_AXIS_SYNONYMS[canonicalFact] || FACT_AXIS_SYNONYMS[fact] || FACT_AXIS_SYNONYMS[keyword] || []) {
+      addUnique(axes.factValidationTerms, synonym)
+    }
+    return
+  }
+
+  if (!LEGAL_CORE_KEYWORDS.has(compact)) {
+    addUnique(axes.factAxis, compact)
+  }
+}
+
+function isKnownFactAxis(term: string): boolean {
+  const compact = term.replace(/\s+/g, "")
+  return FACT_AXIS_PATTERNS.some(pattern => pattern.replace(/\s+/g, "") === compact)
+}
+
+function buildOriginalQueryAxes(originalQuery: string): QueryAxes {
+  const axes: QueryAxes = {
+    legalAxis: [],
+    factAxis: [],
+    legalValidationTerms: [],
+    factValidationTerms: [],
+  }
+  const keywords = extractedOriginalKeywords(originalQuery)
+  const normalizedOriginal = normalizeOriginalPrecedentQuery(originalQuery)
+  const compactOriginal = normalizedOriginal.replace(/\s+/g, "")
+
+  for (const keyword of keywords) {
+    addLegalAxisForKeyword(axes, keyword)
+  }
+
+  for (const pattern of FACT_AXIS_PATTERNS) {
+    if (compactOriginal.includes(pattern.replace(/\s+/g, ""))) {
+      addFactAxisForKeyword(axes, pattern)
+    }
+  }
+  for (const keyword of keywords) {
+    addFactAxisForKeyword(axes, keyword)
+  }
+
+  const hasDomainLegalAxis = axes.legalValidationTerms.some(term => (
+    TAX_DOMAIN_KEYWORDS.has(term) ||
+    CONSTRUCTION_LEGAL_AXIS_KEYWORDS.has(term) ||
+    term.includes("소득세") ||
+    term.includes("조세") ||
+    term.includes("과세") ||
+    term.includes("건설") ||
+    term.includes("하도급")
+  ))
+  if (hasDomainLegalAxis) {
+    axes.legalAxis = axes.legalAxis.filter(term => !GENERIC_LEGAL_ACTION_KEYWORDS.has(term))
+    axes.legalValidationTerms = axes.legalValidationTerms.filter(term => !GENERIC_LEGAL_ACTION_KEYWORDS.has(term))
+  }
+  axes.factAxis = axes.factAxis.filter(keyword => !axes.legalAxis.includes(keyword))
+  return axes
 }
 
 function scoreAiLawArticleCandidate(
@@ -189,13 +463,19 @@ function pushCandidate(
   options: {
     search?: PrecedentSearchScope
     semanticAnchor?: string
+    validationTermGroups?: string[][]
     variantKind?: CompactQueryVariantKind
     requiresResultValidation?: boolean
+    allowSameAsOriginal?: boolean
   } = {}
 ): void {
   const normalized = normalizeCandidate(query)
   const search = options.search ?? 1
-  if (!isUsefulCandidate(normalized, originalQuery)) return
+  if (options.allowSameAsOriginal) {
+    if (!normalized || normalized.length < 2 || normalized.length > 40) return
+  } else if (!isUsefulCandidate(normalized, originalQuery)) {
+    return
+  }
   const key = `${search}:${normalized}`
   if (seen.has(key)) return
   seen.add(key)
@@ -206,68 +486,203 @@ function pushCandidate(
     reason,
     search,
     semanticAnchor: options.semanticAnchor,
-    variantKind: options.variantKind ?? (source === "router" ? "router" : source === "search_retry_hint" ? "retry_hint" : "raw"),
+    validationTermGroups: options.validationTermGroups,
+    variantKind: options.variantKind ?? (
+      source === "case_number" ? "case_number" :
+      source === "original_query" ? "original_query" :
+      source === "original_keyword" ? "original_keyword" :
+      source === "document_hint" ? "document_hint" :
+      source === "router" ? "router" :
+      "raw"
+    ),
     requiresResultValidation: options.requiresResultValidation ?? false,
   })
 }
 
-function addAiLawArticleCandidates(
+function originalKeywordTokens(originalQuery: string): string[] {
+  return extractedOriginalKeywords(originalQuery)
+}
+
+function addCaseNumberCandidate(
   out: CompactQueryCandidate[],
   seen: Set<string>,
   originalQuery: string,
-  aiLawText: string
+  caseNumber?: string
 ): void {
-  let currentLawName = ""
+  const explicit = caseNumber ? normalizeCaseNumber(caseNumber) : ""
+  const detected = extractCaseNumber(originalQuery) || ""
+  const candidate = explicit || detected
+  if (!candidate) return
 
-  for (const line of aiLawText.split("\n")) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-
-    if (/^[가-힣A-Za-z0-9\s·ㆍ]+(법|법률|시행령|시행규칙|규칙|규정|령)$/.test(trimmed)) {
-      currentLawName = trimmed
-      continue
+  pushCandidate(
+    out,
+    seen,
+    originalQuery,
+    candidate,
+    "case_number",
+    300,
+    explicit ? "명시 사건번호" : "원질의 사건번호",
+    {
+      variantKind: "case_number",
+      requiresResultValidation: false,
+      allowSameAsOriginal: true,
     }
+  )
+}
 
-    const titleMatch = trimmed.match(/제\d+조(?:의\d+)?\s*\(([^)]+)\)/)
-    if (!titleMatch) continue
+function addOriginalQueryCandidate(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string
+): void {
+  const normalized = normalizeOriginalPrecedentQuery(originalQuery)
+  if (!normalized) return
+  const useful = normalized === normalizeCandidate(originalQuery)
+    ? normalized.length >= 2 && normalized.length <= 40
+    : true
+  if (!useful) return
 
-    const title = normalizeArticleTitle(titleMatch[1])
-    const variants = titleVariants(title)
-    for (const variant of variants) {
+  pushCandidate(
+    out,
+    seen,
+    originalQuery,
+    normalized,
+    "original_query",
+    260,
+    "원 자연어 질의 정규화",
+    {
+      variantKind: "original_query",
+      requiresResultValidation: false,
+      allowSameAsOriginal: true,
+    }
+  )
+}
+
+function addOriginalKeywordCandidates(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string
+): void {
+  const tokens = originalKeywordTokens(originalQuery)
+  const axes = buildOriginalQueryAxes(originalQuery)
+  if (tokens.length > 8) return
+  if (tokens.length === 0) return
+
+  if (axes.legalAxis.length > 0 && axes.factAxis.length > 0) {
+    const legalPrimary = axes.legalAxis.find(term => !["소득세", "조세", "과세"].includes(term)) || axes.legalAxis[0]
+    const factPrimary = axes.factAxis[0]
+    const validationTermGroups = [
+      axes.legalValidationTerms.length > 0 ? axes.legalValidationTerms : axes.legalAxis,
+      axes.factValidationTerms.length > 0 ? axes.factValidationTerms : axes.factAxis,
+    ]
+
+    pushCandidate(
+      out,
+      seen,
+      originalQuery,
+      `${legalPrimary} ${factPrimary}`,
+      "original_keyword",
+      235,
+      "원질의 법리축 + 사실축 결합",
+      {
+        variantKind: "original_keyword",
+        requiresResultValidation: true,
+        validationTermGroups,
+      }
+    )
+
+    if (axes.legalAxis.length >= 2) {
       pushCandidate(
         out,
         seen,
         originalQuery,
-        variant.query,
-        "ai_law_article_title",
-        100 + variant.scoreDelta,
-        "AI 법령검색 조문 제목",
+        `${axes.legalAxis.slice(0, 2).join(" ")} ${factPrimary}`,
+        "original_keyword",
+        232,
+        "원질의 법리축 확장 + 사실축 결합",
         {
-          search: variant.search,
-          semanticAnchor: title,
-          variantKind: variant.variantKind,
-          requiresResultValidation: variant.requiresResultValidation,
+          variantKind: "original_keyword",
+          requiresResultValidation: true,
+          validationTermGroups,
         }
       )
-
-      if (currentLawName && variant.search === 1) {
-        pushCandidate(
-          out,
-          seen,
-          originalQuery,
-          `${currentLawName} ${variant.query}`,
-          "ai_law_law_article_title",
-          90 + variant.scoreDelta,
-          "AI 법령검색 법령명 + 조문 제목",
-          {
-            search: 1,
-            semanticAnchor: title,
-            variantKind: "law_title",
-            requiresResultValidation: variant.requiresResultValidation,
-          }
-        )
-      }
     }
+
+    if (axes.factAxis.length >= 2 && isKnownFactAxis(axes.factAxis[1])) {
+      pushCandidate(
+        out,
+        seen,
+        originalQuery,
+        `${legalPrimary} ${axes.factAxis[1]}`,
+        "original_keyword",
+        230,
+        "원질의 법리축 + 보조 사실축 결합",
+        {
+          variantKind: "original_keyword",
+          requiresResultValidation: true,
+          validationTermGroups,
+        }
+      )
+    }
+
+    const factSynonym = (FACT_AXIS_SYNONYMS[factPrimary] || [])[0]
+    if (factSynonym) {
+      pushCandidate(
+        out,
+        seen,
+        originalQuery,
+        `${legalPrimary} ${factSynonym}`,
+        "original_keyword",
+        228,
+        "원질의 법리축 + 사실축 유사표현 결합",
+        {
+          variantKind: "original_keyword",
+          requiresResultValidation: true,
+          validationTermGroups,
+        }
+      )
+    }
+
+    return
+  }
+
+  if (tokens.length >= 2) {
+    pushCandidate(
+      out,
+      seen,
+      originalQuery,
+      tokens.slice(0, 3).join(" "),
+      "original_keyword",
+      165,
+      "원질의 핵심 키워드 축약",
+      {
+        variantKind: "original_keyword",
+        requiresResultValidation: true,
+      }
+    )
+  }
+}
+
+function addDocumentHintCandidates(
+  out: CompactQueryCandidate[],
+  seen: Set<string>,
+  originalQuery: string,
+  hints: string[]
+): void {
+  for (const hint of hints) {
+    pushCandidate(
+      out,
+      seen,
+      originalQuery,
+      hint,
+      "document_hint",
+      220,
+      "문서/체인 쟁점 검색 hint",
+      {
+        variantKind: "document_hint",
+        requiresResultValidation: false,
+      }
+    )
   }
 }
 
@@ -324,29 +739,6 @@ function addStructuredAiLawArticleCandidates(
   }
 }
 
-function addRetrySuggestionCandidates(
-  out: CompactQueryCandidate[],
-  seen: Set<string>,
-  originalQuery: string,
-  failedSearchText: string
-): void {
-  for (const line of failedSearchText.split("\n")) {
-    if (!line.includes("재시도 제안")) continue
-    for (const match of line.matchAll(/"([^"]+)"/g)) {
-      pushCandidate(
-        out,
-        seen,
-        originalQuery,
-        match[1],
-        "search_retry_hint",
-        80,
-        "검색 실패 응답의 재시도 제안",
-        { variantKind: "retry_hint" }
-      )
-    }
-  }
-}
-
 function addRouteCandidates(
   out: CompactQueryCandidate[],
   seen: Set<string>,
@@ -361,7 +753,7 @@ function addRouteCandidates(
       originalQuery,
       value,
       "router",
-      70,
+      200,
       "query-router 후보",
       { variantKind: "router" }
     )
@@ -379,16 +771,19 @@ export function buildCompactLegalQueries(input: CompactQueryInput): CompactQuery
   const seen = new Set<string>()
   const candidates: CompactQueryCandidate[] = []
 
-  if (input.aiLawArticles && input.aiLawArticles.length > 0) {
-    addStructuredAiLawArticleCandidates(candidates, seen, input.originalQuery, input.aiLawArticles)
-  } else if (input.aiLawText) {
-    addAiLawArticleCandidates(candidates, seen, input.originalQuery, input.aiLawText)
+  addCaseNumberCandidate(candidates, seen, input.originalQuery, input.caseNumber)
+  if (input.includeOriginal) {
+    addOriginalQueryCandidate(candidates, seen, input.originalQuery)
+    addOriginalKeywordCandidates(candidates, seen, input.originalQuery)
   }
-  if (input.failedSearchText) {
-    addRetrySuggestionCandidates(candidates, seen, input.originalQuery, input.failedSearchText)
+  if (input.documentHints && input.documentHints.length > 0) {
+    addDocumentHintCandidates(candidates, seen, input.originalQuery, input.documentHints)
   }
   if (input.route) {
     addRouteCandidates(candidates, seen, input.originalQuery, input.route)
+  }
+  if (input.aiLawArticles && input.aiLawArticles.length > 0) {
+    addStructuredAiLawArticleCandidates(candidates, seen, input.originalQuery, input.aiLawArticles)
   }
 
   candidates.sort((a, b) => b.score - a.score)

--- a/src/tools/impact-map.ts
+++ b/src/tools/impact-map.ts
@@ -19,7 +19,8 @@ import type { LawApiClient } from "../lib/api-client.js"
 import { findLaws } from "../lib/law-search.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { formatToolError } from "../lib/errors.js"
-import { searchPrecedents } from "./precedents.js"
+import { renderPrecedentSearchResult } from "./precedents.js"
+import { searchPrecedentsStructured } from "./precedent-search-core.js"
 import { searchInterpretations } from "./interpretations.js"
 import { searchAdminAppeals } from "./admin-appeals.js"
 import { searchOrdinance } from "./ordinance-search.js"
@@ -52,6 +53,23 @@ async function safeCall(
     return { text: r.content?.[0]?.text || "", isError: !!r.isError }
   } catch (e) {
     return { text: e instanceof Error ? e.message : String(e), isError: true }
+  }
+}
+
+async function searchPrecedentsWithoutFallback(
+  apiClient: LawApiClient,
+  input: { query: string; display?: number; page?: number; apiKey?: string }
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const result = await searchPrecedentsStructured(apiClient, {
+    ...input,
+    display: input.display ?? 10,
+    page: input.page ?? 1,
+  }, {
+    fallbackPolicy: "none",
+  })
+  return {
+    content: [{ type: "text", text: renderPrecedentSearchResult(result) }],
+    isError: result.hits.length === 0 || undefined,
   }
 }
 
@@ -151,7 +169,7 @@ export async function impactMap(
     // 2. 병렬 탐색
     const [articleR, precR, interpR, appealR, constR, ordinanceR] = await Promise.all([
       safeCall(getArticleDetail, apiClient, { mst: law.mst, jo: joDisplay, apiKey: input.apiKey }),
-      safeCall(searchPrecedents, apiClient, { query: searchQuery, display: 10, apiKey: input.apiKey }),
+      safeCall(searchPrecedentsWithoutFallback, apiClient, { query: searchQuery, display: 10, apiKey: input.apiKey }),
       safeCall(searchInterpretations, apiClient, { query: searchQuery, display: 10, apiKey: input.apiKey }),
       safeCall(searchAdminAppeals, apiClient, { query: searchQuery, display: 5, apiKey: input.apiKey }),
       safeCall(searchConstitutionalDecisions, apiClient, { query: searchQuery, display: 5, apiKey: input.apiKey }),

--- a/src/tools/precedent-evidence.ts
+++ b/src/tools/precedent-evidence.ts
@@ -1,0 +1,194 @@
+import type { LawApiClient } from "../lib/api-client.js"
+import { getPrecedentText } from "./precedents.js"
+import type {
+  PrecedentHit,
+  PrecedentSearchValidationInput,
+  StructuredPrecedentSearchResult,
+} from "./precedent-search-core.js"
+
+export const DEFAULT_PRECEDENT_DETAIL_LIMIT = 2
+export const MAX_PRECEDENT_DETAIL_LIMIT = 5
+
+export interface PrecedentEvidenceOptions {
+  apiKey?: string
+  detailLimit?: number
+  full?: boolean
+}
+
+export interface PrecedentEvidenceItem {
+  hit: PrecedentHit
+  text: string
+  isError: boolean
+  detailError?: string
+}
+
+export interface PrecedentEvidenceResult {
+  text: string
+  isError: boolean
+  items: PrecedentEvidenceItem[]
+}
+
+function normalizeRelevanceText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, "")
+}
+
+function validationTerms(input: PrecedentSearchValidationInput): string[] {
+  return Array.from(new Set([
+    input.attempt.semanticAnchor,
+    input.attempt.query,
+  ].filter((term): term is string => typeof term === "string" && normalizeRelevanceText(term).length >= 2)))
+}
+
+function validationTermGroups(input: PrecedentSearchValidationInput): string[][] {
+  return (input.attempt.validationTermGroups || [])
+    .map(group => Array.from(new Set(group.filter(term => normalizeRelevanceText(term).length >= 2))))
+    .filter(group => group.length > 0)
+}
+
+function containsAnyTerm(text: string, terms: string[]): boolean {
+  const haystack = normalizeRelevanceText(text)
+  return terms.some(term => haystack.includes(normalizeRelevanceText(term)))
+}
+
+function containsEveryTermGroup(text: string, groups: string[][]): boolean {
+  return groups.every(group => containsAnyTerm(text, group))
+}
+
+function clampDetailLimit(limit?: number): number {
+  const value = Math.trunc(limit ?? DEFAULT_PRECEDENT_DETAIL_LIMIT)
+  if (!Number.isFinite(value) || value < 1) return DEFAULT_PRECEDENT_DETAIL_LIMIT
+  return Math.min(value, MAX_PRECEDENT_DETAIL_LIMIT)
+}
+
+function renderHeader(count: number, full: boolean): string {
+  return `자동 상세조회: search_precedents -> get_precedent_text (상위 ${count}건, full=${full ? "true" : "false"})`
+}
+
+async function fetchOnePrecedentDetail(
+  apiClient: LawApiClient,
+  hit: PrecedentHit,
+  options: PrecedentEvidenceOptions
+): Promise<PrecedentEvidenceItem> {
+  try {
+    const result = await getPrecedentText(apiClient, {
+      id: hit.id,
+      full: options.full ?? false,
+      apiKey: options.apiKey,
+    })
+    const text = result.content?.map(item => item.text).join("\n") || ""
+    if (result.isError) {
+      return {
+        hit,
+        text,
+        isError: true,
+        detailError: text || "상세조회 결과가 비어 있습니다.",
+      }
+    }
+    return {
+      hit,
+      text,
+      isError: false,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      hit,
+      text: "",
+      isError: true,
+      detailError: message,
+    }
+  }
+}
+
+function renderEvidenceItem(item: PrecedentEvidenceItem): string {
+  const title = item.hit.title ? ` ${item.hit.title}` : ""
+  if (item.isError) {
+    return `[${item.hit.id}]${title}\n상세조회 실패: ${item.detailError || "원인을 확인할 수 없습니다."}`
+  }
+  return `[${item.hit.id}]${title}\n${item.text || "상세조회 결과가 비어 있습니다."}`
+}
+
+function validationSearchResult(input: PrecedentSearchValidationInput): StructuredPrecedentSearchResult {
+  return {
+    originalArgs: input.originalArgs,
+    totalCount: input.hits.length,
+    page: 1,
+    hits: input.hits,
+    attempts: [input.attempt],
+    fallbackUsed: true,
+    successfulAttempt: input.attempt,
+  }
+}
+
+export async function validatePrecedentSearchResult(
+  apiClient: LawApiClient,
+  input: PrecedentSearchValidationInput,
+  options: PrecedentEvidenceOptions = {}
+): Promise<boolean> {
+  const groups = validationTermGroups(input)
+  const terms = validationTerms(input)
+  if (groups.length === 0 && terms.length === 0) return true
+
+  const listText = input.hits
+    .map(hit => [hit.title, hit.caseNumber, hit.court, hit.date, hit.decisionType].filter(Boolean).join(" "))
+    .join("\n")
+  if (groups.length > 0 && containsEveryTermGroup(listText, groups)) return true
+  if (groups.length > 0) {
+    const evidence = await fetchPrecedentEvidence(
+      apiClient,
+      validationSearchResult(input),
+      {
+        apiKey: options.apiKey,
+        detailLimit: 1,
+        full: input.attempt.search === 2 || options.full === true,
+      }
+    )
+    if (!evidence || evidence.isError) return false
+
+    return evidence.items.some(item => !item.isError && containsEveryTermGroup(item.text, groups))
+  }
+  if (containsAnyTerm(listText, terms)) return true
+
+  const evidence = await fetchPrecedentEvidence(
+    apiClient,
+    validationSearchResult(input),
+    {
+      apiKey: options.apiKey,
+      detailLimit: 1,
+      full: input.attempt.search === 2 || options.full === true,
+    }
+  )
+  if (!evidence || evidence.isError) return false
+
+  return evidence.items.some(item => !item.isError && containsAnyTerm(item.text, terms))
+}
+
+export async function fetchPrecedentEvidence(
+  apiClient: LawApiClient,
+  searchResult: StructuredPrecedentSearchResult,
+  options: PrecedentEvidenceOptions = {}
+): Promise<PrecedentEvidenceResult | null> {
+  const hits = searchResult.hits
+    .filter(hit => !!hit.id)
+    .slice(0, clampDetailLimit(options.detailLimit))
+
+  if (hits.length === 0) return null
+
+  const items = await Promise.all(
+    hits.map(hit => fetchOnePrecedentDetail(apiClient, hit, options))
+  )
+  const failures = items.filter(item => item.isError).length
+  const blocks = [
+    renderHeader(items.length, options.full ?? false),
+    ...items.map(renderEvidenceItem),
+  ]
+
+  return {
+    text: blocks.join("\n\n"),
+    isError: failures === items.length,
+    items,
+  }
+}

--- a/src/tools/precedent-search-core.ts
+++ b/src/tools/precedent-search-core.ts
@@ -1,0 +1,374 @@
+import type { LawApiClient } from "../lib/api-client.js"
+import { parsePrecedentXML, type PrecedentItem } from "../lib/xml-parser.js"
+import { buildCompactLegalQueries } from "./compact-query-planner.js"
+import type { AiLawArticleSignal } from "./life-law.js"
+import type { SearchPrecedentsInput } from "./precedents.js"
+
+export type PrecedentSearchMode = 1 | 2
+
+export interface PrecedentSearchAttempt {
+  query?: string
+  caseNumber?: string
+  search?: PrecedentSearchMode
+  fromDate?: string
+  toDate?: string
+  reason: string
+  totalCount: number
+  hitCount: number
+  success: boolean
+  outOfRequestedDateRange?: boolean
+  semanticAnchor?: string
+  validationTermGroups?: string[][]
+  requiresResultValidation?: boolean
+  validationFailed?: boolean
+  error?: string
+}
+
+export interface PrecedentHit {
+  id: string
+  title: string
+  caseNumber?: string
+  court?: string
+  date?: string
+  decisionType?: string
+  link?: string
+  sourceQuery?: string
+  semanticAnchor?: string
+  searchMode: PrecedentSearchMode
+  outOfRequestedDateRange?: boolean
+}
+
+export interface StructuredPrecedentSearchResult {
+  originalArgs: SearchPrecedentsInput
+  totalCount: number
+  page: number
+  hits: PrecedentHit[]
+  attempts: PrecedentSearchAttempt[]
+  fallbackUsed: boolean
+  successfulAttempt?: PrecedentSearchAttempt
+}
+
+export interface PrecedentSearchContext {
+  aiLawArticles?: AiLawArticleSignal[]
+  route?: {
+    params?: Record<string, unknown>
+    pipeline?: Array<{ params?: Record<string, unknown> }>
+  }
+  documentHints?: string[]
+  fallbackPolicy?: "full" | "body" | "none"
+  maxFallbackAttempts?: number
+  validateResult?: (input: PrecedentSearchValidationInput) => boolean | Promise<boolean>
+}
+
+export interface PrecedentSearchValidationInput {
+  originalArgs: SearchPrecedentsInput
+  attempt: PrecedentSearchAttempt
+  hits: PrecedentHit[]
+}
+
+interface SearchOnceInput {
+  query?: string
+  caseNumber?: string
+  search: PrecedentSearchMode
+  reason: string
+  semanticAnchor?: string
+  validationTermGroups?: string[][]
+  requiresResultValidation?: boolean
+  relaxDateRange?: boolean
+}
+
+interface SearchOnceResult {
+  attempt: PrecedentSearchAttempt
+  page: number
+  hits: PrecedentHit[]
+  rawHits: PrecedentHit[]
+}
+
+function cleanDate(date?: string): string | undefined {
+  const value = (date || "").replace(/[.\-\s]/g, "")
+  return value || undefined
+}
+
+function isDateInRange(date: string | undefined, fromDate?: string, toDate?: string): boolean {
+  const normalized = cleanDate(date)
+  if (!normalized) return true
+  if (fromDate && normalized < fromDate) return false
+  if (toDate && normalized > toDate) return false
+  return true
+}
+
+function hasDateRange(args: SearchPrecedentsInput): boolean {
+  return !!(args.fromDate || args.toDate)
+}
+
+function resultTotalCount(args: SearchPrecedentsInput, attempt: PrecedentSearchAttempt, hits: PrecedentHit[]): number {
+  return hasDateRange(args) ? hits.length : attempt.totalCount
+}
+
+function toHit(
+  item: PrecedentItem,
+  sourceQuery: string | undefined,
+  searchMode: PrecedentSearchMode,
+  semanticAnchor?: string
+): PrecedentHit {
+  return {
+    id: item.판례일련번호,
+    title: item.판례명,
+    caseNumber: item.사건번호 || undefined,
+    court: item.법원명 || undefined,
+    date: cleanDate(item.선고일자) || item.선고일자 || undefined,
+    decisionType: item.판결유형 || undefined,
+    link: item.판례상세링크 || undefined,
+    sourceQuery,
+    semanticAnchor,
+    searchMode,
+  }
+}
+
+function attemptKey(input: SearchOnceInput): string {
+  if (input.caseNumber) return `case:${input.caseNumber}`
+  return `query:${input.search}:${input.query || ""}`
+}
+
+function markDateRelaxed(hits: PrecedentHit[], args: SearchPrecedentsInput): PrecedentHit[] {
+  return hits.map(hit => ({
+    ...hit,
+    outOfRequestedDateRange: !isDateInRange(hit.date, args.fromDate, args.toDate),
+  }))
+}
+
+async function runPrecedentSearchOnce(
+  apiClient: LawApiClient,
+  args: SearchPrecedentsInput,
+  input: SearchOnceInput
+): Promise<SearchOnceResult> {
+  const extraParams: Record<string, string> = {
+    display: String(args.display || 20),
+    page: String(args.page || 1),
+  }
+  if (input.query) extraParams.query = input.query
+  if (input.search === 2) extraParams.search = "2"
+  if (input.caseNumber) extraParams.nb = input.caseNumber
+  if (args.court) extraParams.curt = args.court
+  if (args.sort) extraParams.sort = args.sort
+
+  const xmlText = await apiClient.fetchApi({
+    endpoint: "lawSearch.do",
+    target: "prec",
+    extraParams,
+    apiKey: args.apiKey,
+  })
+  const parsed = parsePrecedentXML(xmlText)
+  const rawHits = parsed.items.map(item => toHit(item, input.query, input.search, input.semanticAnchor))
+  const hits = input.relaxDateRange || !hasDateRange(args)
+    ? markDateRelaxed(rawHits, args)
+    : rawHits.filter(hit => isDateInRange(hit.date, args.fromDate, args.toDate))
+
+  const attempt: PrecedentSearchAttempt = {
+    query: input.query,
+    caseNumber: input.caseNumber,
+    search: input.search,
+    fromDate: args.fromDate,
+    toDate: args.toDate,
+    reason: input.reason,
+    totalCount: parsed.totalCnt,
+    hitCount: hits.length,
+    success: hits.length > 0,
+    outOfRequestedDateRange: input.relaxDateRange ? hits.some(hit => hit.outOfRequestedDateRange) : undefined,
+    semanticAnchor: input.semanticAnchor,
+    validationTermGroups: input.validationTermGroups,
+    requiresResultValidation: input.requiresResultValidation,
+  }
+
+  return {
+    attempt,
+    page: parsed.page,
+    hits,
+    rawHits,
+  }
+}
+
+function firstAttempt(args: SearchPrecedentsInput): SearchOnceInput {
+  if (args.caseNumber) {
+    return {
+      caseNumber: args.caseNumber,
+      search: (args.search || 1) as PrecedentSearchMode,
+      reason: "case_number",
+    }
+  }
+
+  return {
+    query: args.query,
+    search: (args.search || 1) as PrecedentSearchMode,
+    reason: "original_query",
+  }
+}
+
+function fallbackInputs(args: SearchPrecedentsInput, context: PrecedentSearchContext): SearchOnceInput[] {
+  const originalQuery = args.query || args.caseNumber || ""
+  const inputs: SearchOnceInput[] = []
+  const fallbackPolicy = context.fallbackPolicy ?? "full"
+
+  if (fallbackPolicy === "none") return inputs
+
+  if (args.query && (args.search || 1) === 1) {
+    inputs.push({
+      query: args.query,
+      search: 2,
+      reason: "body_search",
+    })
+  }
+
+  if (fallbackPolicy === "body") return inputs
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery,
+    includeOriginal: true,
+    caseNumber: args.caseNumber,
+    documentHints: context.documentHints,
+    aiLawArticles: context.aiLawArticles,
+    route: context.route,
+    max: context.maxFallbackAttempts ?? 5,
+  })
+
+  for (const candidate of candidates) {
+    const requiresResultValidation = candidate.requiresResultValidation ||
+      candidate.source === "ai_law_article_title" ||
+      candidate.source === "ai_law_law_article_title"
+    if (candidate.source === "case_number") {
+      inputs.push({
+        caseNumber: candidate.query,
+        search: candidate.search,
+        reason: "case_number",
+        semanticAnchor: candidate.semanticAnchor,
+        validationTermGroups: candidate.validationTermGroups,
+        requiresResultValidation,
+      })
+    } else {
+      inputs.push({
+        query: candidate.query,
+        search: candidate.search,
+        reason: candidate.source,
+        semanticAnchor: candidate.semanticAnchor,
+        validationTermGroups: candidate.validationTermGroups,
+        requiresResultValidation,
+      })
+    }
+  }
+
+  return inputs
+}
+
+export async function searchPrecedentsStructured(
+  apiClient: LawApiClient,
+  args: SearchPrecedentsInput,
+  context: PrecedentSearchContext = {}
+): Promise<StructuredPrecedentSearchResult> {
+  const attempts: PrecedentSearchAttempt[] = []
+  const seen = new Set<string>()
+  let page = args.page || 1
+  const dateRelaxationCandidates: SearchOnceResult[] = []
+
+  const run = async (input: SearchOnceInput): Promise<SearchOnceResult | null> => {
+    const key = attemptKey(input)
+    if (seen.has(key)) return null
+    seen.add(key)
+
+    const result = await runPrecedentSearchOnce(apiClient, args, input)
+    attempts.push(result.attempt)
+    page = result.page
+
+    if (result.attempt.success && result.attempt.requiresResultValidation && context.validateResult) {
+      try {
+        const accepted = await context.validateResult({
+          originalArgs: args,
+          attempt: result.attempt,
+          hits: result.hits,
+        })
+        if (!accepted) {
+          result.attempt.success = false
+          result.attempt.hitCount = 0
+          result.attempt.validationFailed = true
+          result.attempt.error = "validation_failed"
+          result.hits = []
+        }
+      } catch (error) {
+        result.attempt.success = false
+        result.attempt.hitCount = 0
+        result.attempt.validationFailed = true
+        result.attempt.error = error instanceof Error ? error.message : String(error)
+        result.hits = []
+      }
+    }
+
+    if (
+      hasDateRange(args) &&
+      result.rawHits.length > 0 &&
+      result.hits.length === 0 &&
+      !result.attempt.validationFailed &&
+      dateRelaxationCandidates.length === 0
+    ) {
+      dateRelaxationCandidates.push(result)
+    }
+    return result
+  }
+
+  const initial = await run(firstAttempt(args))
+  if (initial?.attempt.success) {
+    return {
+      originalArgs: args,
+      totalCount: resultTotalCount(args, initial.attempt, initial.hits),
+      page,
+      hits: initial.hits,
+      attempts,
+      fallbackUsed: false,
+      successfulAttempt: initial.attempt,
+    }
+  }
+
+  for (const input of fallbackInputs(args, context)) {
+    const result = await run(input)
+    if (result?.attempt.success) {
+      return {
+        originalArgs: args,
+        totalCount: resultTotalCount(args, result.attempt, result.hits),
+        page,
+        hits: result.hits,
+        attempts,
+        fallbackUsed: true,
+        successfulAttempt: result.attempt,
+      }
+    }
+  }
+
+  const dateRelaxationCandidate = dateRelaxationCandidates[0]
+  if (dateRelaxationCandidate) {
+    const relaxedHits = markDateRelaxed(dateRelaxationCandidate.rawHits, args)
+    const relaxedAttempt: PrecedentSearchAttempt = {
+      ...dateRelaxationCandidate.attempt,
+      reason: "date_relaxed",
+      hitCount: relaxedHits.length,
+      success: relaxedHits.length > 0,
+      outOfRequestedDateRange: relaxedHits.some(hit => hit.outOfRequestedDateRange),
+    }
+    attempts.push(relaxedAttempt)
+    return {
+      originalArgs: args,
+      totalCount: resultTotalCount(args, relaxedAttempt, relaxedHits),
+      page,
+      hits: relaxedHits,
+      attempts,
+      fallbackUsed: true,
+      successfulAttempt: relaxedAttempt,
+    }
+  }
+
+  return {
+    originalArgs: args,
+    totalCount: 0,
+    page,
+    hits: [],
+    attempts,
+    fallbackUsed: attempts.length > 1,
+  }
+}

--- a/src/tools/precedents.ts
+++ b/src/tools/precedents.ts
@@ -1,7 +1,6 @@
 import { z } from "zod"
 import type { LawApiClient } from "../lib/api-client.js"
 import { cleanHtml } from "../lib/article-parser.js"
-import { parsePrecedentXML } from "../lib/xml-parser.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { formatToolError } from "../lib/errors.js"
 import { fetchWithRetry } from "../lib/fetch-with-retry.js"
@@ -16,6 +15,7 @@ import {
   densifyPrecedentRefs,
   stripRepeatedSummary,
 } from "../lib/decision-compact.js"
+import { searchPrecedentsStructured, type StructuredPrecedentSearchResult } from "./precedent-search-core.js"
 
 export const searchPrecedentsSchema = z.object({
   query: z.string().optional().describe("검색 키워드 (예: '자동차', '담보권')"),
@@ -34,90 +34,87 @@ export const searchPrecedentsSchema = z.object({
 
 export type SearchPrecedentsInput = z.infer<typeof searchPrecedentsSchema>;
 
+function renderNoPrecedentResult(result: StructuredPrecedentSearchResult): string {
+  const kw = result.originalArgs.query || result.originalArgs.caseNumber || "관련 키워드"
+  const keywords = kw.trim().split(/\s+/)
+  const lines = [`[NOT_FOUND] '${kw}' 판례 검색 결과가 없습니다.`, "", "⚠️ LLM은 판례를 추측/생성하지 마세요. 사용자에게 '검색 실패'를 보고하세요."]
+  if (keywords.length >= 2) {
+    lines.push("")
+    lines.push("힌트: 법제처 API는 공백 구분 키워드를 AND 조건으로 처리합니다. 키워드가 많을수록 결과가 줄어듭니다.")
+    lines.push(`재시도 제안: "${keywords[0]}" 또는 "${keywords.slice(0, 2).join(" ")}"`)
+  }
+  if (result.attempts.length > 1) {
+    lines.push("")
+    lines.push(`검색 보정 시도: ${result.attempts.map(attempt => {
+      const label = attempt.caseNumber || attempt.query || "(빈 검색어)"
+      const scope = attempt.search === 2 ? ", 본문검색" : ""
+      return `${label}${scope}`
+    }).join(" → ")}`)
+  }
+  lines.push("")
+  lines.push("대안:")
+  lines.push(`  1. 해석례 검색: search_interpretations(query="${kw}")`)
+  lines.push(`  2. 법령 검색: search_law(query="${kw}")`)
+  return lines.join("\n")
+}
+
+export function renderPrecedentSearchResult(result: StructuredPrecedentSearchResult): string {
+  const args = result.originalArgs
+  if (result.hits.length === 0) return renderNoPrecedentResult(result)
+
+  let output = `판례 검색 결과 (총 ${result.totalCount}건, ${result.page}페이지)`
+  if (args.fromDate || args.toDate) {
+    output += ` [기간: ${args.fromDate || "시작"} ~ ${args.toDate || "종료"}]`
+  }
+  output += `:\n\n`
+
+  for (const hit of result.hits) {
+    output += `[${hit.id}] ${hit.title}\n`
+    output += `  사건번호: ${hit.caseNumber || "N/A"}\n`
+    output += `  법원: ${hit.court || "N/A"}\n`
+    output += `  선고일: ${hit.date || "N/A"}\n`
+    output += `  판결유형: ${hit.decisionType || "N/A"}\n`
+    if (hit.outOfRequestedDateRange) {
+      output += `  범위: 요청 기간 밖 fallback 결과\n`
+    }
+    if (hit.link) {
+      output += `  링크: ${hit.link}\n`
+    }
+    output += `\n`
+  }
+
+  if (result.fallbackUsed && result.successfulAttempt) {
+    const attempt = result.successfulAttempt
+    const label = attempt.caseNumber || attempt.query || "(빈 검색어)"
+    const scope = attempt.search === 2 ? "본문검색" : "제목검색"
+    const dateNote = attempt.outOfRequestedDateRange ? ", 요청 기간 밖 결과 포함" : ""
+    output += `검색 보정: ${attempt.reason}="${label}" (${scope}${dateNote})\n\n`
+  }
+
+  if (result.hits[0]?.id) {
+    output += `💡 다음: get_precedent_text(id="${result.hits[0].id}") 로 판결문 전문. full=true 로 축약 해제. 유사판례 원하면 find_similar_precedents 사용.\n`
+  }
+
+  return output
+}
+
 export async function searchPrecedents(
   apiClient: LawApiClient,
   args: SearchPrecedentsInput
 ): Promise<{ content: Array<{ type: string, text: string }>, isError?: boolean }> {
   try {
-    const extraParams: Record<string, string> = {
-      display: (args.display || 20).toString(),
-      page: (args.page || 1).toString(),
-    };
-    if (args.query) extraParams.query = args.query;
-    if (args.search) extraParams.search = args.search.toString();
-    if (args.court) extraParams.curt = args.court;
-    if (args.caseNumber) extraParams.nb = args.caseNumber;
-    if (args.sort) extraParams.sort = args.sort;
-
-    const xmlText = await apiClient.fetchApi({
-      endpoint: "lawSearch.do",
-      target: "prec",
-      extraParams,
-      apiKey: args.apiKey,
-    });
-
-  // 공통 파서 사용
-  const result = parsePrecedentXML(xmlText);
-  const currentPage = result.page;
-  let precs = result.items;
-
-  // 날짜 범위 필터링 (클라이언트 사이드)
-  if (args.fromDate || args.toDate) {
-    precs = precs.filter(p => {
-      const d = (p.선고일자 || "").replace(/[.\-\s]/g, "")
-      if (!d) return true
-      if (args.fromDate && d < args.fromDate) return false
-      if (args.toDate && d > args.toDate) return false
-      return true
+    const { validatePrecedentSearchResult } = await import("./precedent-evidence.js")
+    const result = await searchPrecedentsStructured(apiClient, args, {
+      validateResult: validation => validatePrecedentSearchResult(apiClient, validation, { apiKey: args.apiKey }),
     })
-  }
-  const totalCount = (args.fromDate || args.toDate) ? precs.length : result.totalCnt;
-
-  if (totalCount === 0) {
-    const kw = args.query || "관련 키워드"
-    const keywords = kw.trim().split(/\s+/)
-    const lines = [`[NOT_FOUND] '${kw}' 판례 검색 결과가 없습니다.`, "", "⚠️ LLM은 판례를 추측/생성하지 마세요. 사용자에게 '검색 실패'를 보고하세요."]
-    if (keywords.length >= 2) {
-      lines.push("")
-      lines.push("힌트: 법제처 API는 공백 구분 키워드를 AND 조건으로 처리합니다. 키워드가 많을수록 결과가 줄어듭니다.")
-      lines.push(`재시도 제안: "${keywords[0]}" 또는 "${keywords.slice(0, 2).join(" ")}"`)
-    }
-    lines.push("")
-    lines.push("대안:")
-    lines.push(`  1. 해석례 검색: search_interpretations(query="${kw}")`)
-    lines.push(`  2. 법령 검색: search_law(query="${kw}")`)
-    return { content: [{ type: "text", text: lines.join("\n") }], isError: true };
-  }
-
-  let output = `판례 검색 결과 (총 ${totalCount}건, ${currentPage}페이지)`;
-  if (args.fromDate || args.toDate) {
-    output += ` [기간: ${args.fromDate || "시작"} ~ ${args.toDate || "종료"}]`
-  }
-  output += `:\n\n`;
-
-  for (const prec of precs) {
-    output += `[${prec.판례일련번호}] ${prec.판례명}\n`;
-    output += `  사건번호: ${prec.사건번호 || "N/A"}\n`;
-    output += `  법원: ${prec.법원명 || "N/A"}\n`;
-    output += `  선고일: ${prec.선고일자 || "N/A"}\n`;
-    output += `  판결유형: ${prec.판결유형 || "N/A"}\n`;
-    if (prec.판례상세링크) {
-      output += `  링크: ${prec.판례상세링크}\n`;
-    }
-    output += `\n`;
-  }
-
-  // 다음 단계 힌트
-  if (precs.length > 0 && precs[0].판례일련번호) {
-    output += `💡 다음: get_precedent_text(id="${precs[0].판례일련번호}") 로 판결문 전문. full=true 로 축약 해제. 유사판례 원하면 find_similar_precedents 사용.\n`
-  }
-
-  return {
-    content: [{
-      type: "text",
-      text: truncateResponse(output)
-    }]
-  };
+    const output = renderPrecedentSearchResult(result)
+    return {
+      content: [{
+        type: "text",
+        text: truncateResponse(output)
+      }],
+      isError: result.hits.length === 0 || undefined,
+    };
   } catch (error) {
     return formatToolError(error, "search_precedents")
   }

--- a/src/tools/unified-decisions.ts
+++ b/src/tools/unified-decisions.ts
@@ -13,7 +13,7 @@ import { formatToolError } from "../lib/errors.js"
 import { compactLongSections } from "../lib/decision-compact.js"
 
 // 기존 handler 재사용 (함수 직접 import)
-import { searchPrecedents, getPrecedentText } from "./precedents.js"
+import { searchPrecedents, getPrecedentText, renderPrecedentSearchResult } from "./precedents.js"
 import { searchInterpretations, getInterpretationText } from "./interpretations.js"
 import { searchTaxTribunalDecisions, getTaxTribunalDecisionText } from "./tax-tribunal-decisions.js"
 import {
@@ -35,6 +35,8 @@ import {
 import { searchSchoolRules, getSchoolRuleText, searchPublicCorpRules, getPublicCorpRuleText, searchPublicInstitutionRules, getPublicInstitutionRuleText } from "./institutional-rules.js"
 import { searchTreaties, getTreatyText } from "./treaties.js"
 import { searchEnglishLaw, getEnglishLawText } from "./english-law.js"
+import { searchPrecedentsStructured } from "./precedent-search-core.js"
+import { fetchPrecedentEvidence, validatePrecedentSearchResult } from "./precedent-evidence.js"
 
 // ========================================
 // Domain enum & config
@@ -141,6 +143,42 @@ export const SearchDecisionsSchema = z.object({
 
 export type SearchDecisionsInput = z.infer<typeof SearchDecisionsSchema>
 
+function isEnabled(value: unknown): boolean {
+  return value === true || value === "true"
+}
+
+function getPositiveIntegerOption(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value)
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return Math.trunc(parsed)
+  }
+  return undefined
+}
+
+async function searchPrecedentDecisionsWithText(
+  apiClient: LawApiClient,
+  args: Record<string, unknown>,
+  detailLimit?: number
+): Promise<LooseToolResponse> {
+  const apiKey = typeof args.apiKey === "string" ? args.apiKey : undefined
+  const searchResult = await searchPrecedentsStructured(apiClient, args as any, {
+    validateResult: validation => validatePrecedentSearchResult(apiClient, validation, { apiKey }),
+  })
+  const listText = renderPrecedentSearchResult(searchResult)
+  const evidence = await fetchPrecedentEvidence(apiClient, searchResult, {
+    apiKey,
+    detailLimit,
+    full: false,
+  })
+  const text = evidence ? `${listText}\n\n▶ 관련 판례 상세\n${evidence.text}` : listText
+
+  return {
+    content: [{ type: "text", text: truncateResponse(text) }],
+    isError: searchResult.hits.length === 0 || undefined,
+  }
+}
+
 export async function searchDecisions(
   apiClient: LawApiClient,
   input: SearchDecisionsInput
@@ -169,6 +207,14 @@ export async function searchDecisions(
       for (const [k, v] of Object.entries(input.options)) {
         if (!reserved.has(k)) args[k] = v
       }
+    }
+
+    if (input.domain === "precedent" && isEnabled(input.options?.includeText)) {
+      return await searchPrecedentDecisionsWithText(
+        apiClient,
+        args,
+        getPositiveIntegerOption(input.options?.detailLimit)
+      )
     }
 
     return await handler(apiClient, args)

--- a/test/test-chain-full-research-precedent-retry.cjs
+++ b/test/test-chain-full-research-precedent-retry.cjs
@@ -277,20 +277,27 @@ async function testUsesAiLawIssueBeforeRawFirstWord(chainFullResearch) {
   const result = await chainFullResearch(apiClient, { query: PHOTO_QUERY, apiKey: "test" })
   const text = result.content?.[0]?.text || ""
 
-  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [PHOTO_QUERY, "사생활 침해"])
+  assert.strictEqual(apiClient.precedentRequests[0].query, PHOTO_QUERY)
+  assert.strictEqual(apiClient.precedentRequests[0].search, "1")
+  assert.ok(apiClient.precedentRequests.some((request) => request.query === PHOTO_QUERY && request.search === "2"))
+  assert.ok(apiClient.precedentQueries.includes("사생활 침해"), apiClient.precedentQueries.join(", "))
   assert.ok(!apiClient.precedentQueries.includes("공원에서"), apiClient.precedentQueries.join(", "))
-  assert.ok(text.includes('재검색어 "사생활 침해"'), text)
+  assert.ok(text.includes('검색 보정: ai_law_article_title="사생활 침해"'), text)
   assert.ok(text.includes("중고거래 물품대금 반환 사건"), text)
 }
 
 async function testRetriesSuggestedKeywordAfterRawPrecedentFailure(chainFullResearch) {
-  const apiClient = makeApiClient({ succeedOnQuery: "중고거래" })
+  const apiClient = makeApiClient({ succeedOnQuery: "중고거래 구매자 단순" })
 
   const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
   const text = result.content?.[0]?.text || ""
 
-  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "중고거래"])
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"중고거래\""), text)
+  assert.strictEqual(apiClient.precedentRequests[0].query, QUERY)
+  assert.strictEqual(apiClient.precedentRequests[0].search, "1")
+  assert.ok(apiClient.precedentRequests.some((request) => request.query === QUERY && request.search === "2"))
+  assert.ok(apiClient.precedentQueries.includes("중고거래 구매자 단순"), apiClient.precedentQueries.join(", "))
+  assert.ok(!apiClient.precedentQueries.includes("중고거래"), apiClient.precedentQueries.join(", "))
+  assert.ok(text.includes('검색 보정: original_keyword="중고거래 구매자 단순"'), text)
   assert.ok(text.includes("중고거래 물품대금 반환 사건"), text)
 }
 
@@ -303,9 +310,10 @@ async function testIgnoresQuotedLawNameFragments(chainFullResearch) {
   const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
   const text = result.content?.[0]?.text || ""
 
-  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
+  assert.strictEqual(apiClient.precedentQueries[0], QUERY)
+  assert.ok(apiClient.precedentQueries.includes("청약철회"), apiClient.precedentQueries.join(", "))
   assert.ok(!apiClient.precedentQueries.includes("소비자보호"), apiClient.precedentQueries.join(", "))
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+  assert.ok(text.includes('검색 보정: ai_law_article_title="청약철회"'), text)
 }
 
 async function testIgnoresGenericContractPhrase(chainFullResearch) {
@@ -317,9 +325,10 @@ async function testIgnoresGenericContractPhrase(chainFullResearch) {
   const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
   const text = result.content?.[0]?.text || ""
 
-  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
+  assert.strictEqual(apiClient.precedentQueries[0], QUERY)
+  assert.ok(apiClient.precedentQueries.includes("청약철회"), apiClient.precedentQueries.join(", "))
   assert.ok(!apiClient.precedentQueries.includes("관한 계약"), apiClient.precedentQueries.join(", "))
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+  assert.ok(text.includes('검색 보정: ai_law_article_title="청약철회"'), text)
 }
 
 async function testDoesNotRetryGenericDefinitionBeforeSpecificTitle(chainFullResearch) {
@@ -331,9 +340,10 @@ async function testDoesNotRetryGenericDefinitionBeforeSpecificTitle(chainFullRes
   const result = await chainFullResearch(apiClient, { query: QUERY, apiKey: "test" })
   const text = result.content?.[0]?.text || ""
 
-  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [QUERY, "청약철회"])
+  assert.strictEqual(apiClient.precedentQueries[0], QUERY)
+  assert.ok(apiClient.precedentQueries.includes("청약철회"), apiClient.precedentQueries.join(", "))
   assert.ok(!apiClient.precedentQueries.includes("정의"), apiClient.precedentQueries.join(", "))
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회\""), text)
+  assert.ok(text.includes('검색 보정: ai_law_article_title="청약철회"'), text)
 }
 
 async function testUsesBodySearchForSpacedTerminalVariant(chainFullResearch) {
@@ -349,7 +359,7 @@ async function testUsesBodySearchForSpacedTerminalVariant(chainFullResearch) {
     apiClient.precedentRequests.some((request) => request.query === "청약철회 등" && request.search === "2"),
     JSON.stringify(apiClient.precedentRequests)
   )
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회 등\""), text)
+  assert.ok(text.includes('검색 보정: ai_law_article_title="청약철회 등" (본문검색)'), text)
 }
 
 async function testBodySearchValidationUsesFullDetailText(chainFullResearch) {
@@ -374,7 +384,7 @@ async function testBodySearchValidationUsesFullDetailText(chainFullResearch) {
     apiClient.precedentRequests.some((request) => request.query === "청약철회 등" && request.search === "2"),
     JSON.stringify(apiClient.precedentRequests)
   )
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"청약철회 등\""), text)
+  assert.ok(text.includes('검색 보정: ai_law_article_title="청약철회 등" (본문검색)'), text)
 }
 
 async function testRejectsUnrelatedNonEmptyRetryResult(chainFullResearch) {
@@ -392,7 +402,7 @@ async function testRejectsUnrelatedNonEmptyRetryResult(chainFullResearch) {
   const text = result.content?.[0]?.text || ""
 
   assert.ok(apiClient.precedentQueries.length > 2, apiClient.precedentQueries.join(", "))
-  assert.ok(!text.includes("판례 1차 검색 실패 후 재검색어"), text)
+  assert.ok(!text.includes("검색 보정:"), text)
   assert.ok(!text.includes("자동차 보험금 사건"), text)
 }
 
@@ -408,11 +418,9 @@ async function testUsesAiLawArticleTitleCandidate(chainFullResearch) {
   })
   const text = result.content?.[0]?.text || ""
 
-  assert.deepStrictEqual(apiClient.precedentQueries.slice(0, 2), [
-    "채용 과정에서 불합리한 대우를 받았습니다",
-    "취업기회의 균등한 보장",
-  ])
-  assert.ok(text.includes("판례 1차 검색 실패 후 재검색어 \"취업기회의 균등한 보장\""), text)
+  assert.strictEqual(apiClient.precedentQueries[0], "채용 과정에서 불합리한 대우를 받았습니다")
+  assert.ok(apiClient.precedentQueries.includes("취업기회의 균등한 보장"), apiClient.precedentQueries.join(", "))
+  assert.ok(text.includes('검색 보정: ai_law_article_title="취업기회의 균등한 보장"'), text)
 }
 
 async function testUsesLowConfidenceLawTextFallback(chainFullResearch) {
@@ -459,10 +467,13 @@ async function testLimitsPrecedentRetriesToFive(chainFullResearch) {
     apiKey: "test",
   })
 
-  assert.strictEqual(
-    apiClient.precedentQueries.length,
-    6,
-    `expected raw precedent search plus five retries, got ${apiClient.precedentQueries.length}: ${apiClient.precedentQueries.join(", ")}`
+  assert.ok(
+    apiClient.precedentQueries.length <= 7,
+    `expected no more than raw precedent search, body search, and five fallback attempts, got ${apiClient.precedentQueries.length}: ${apiClient.precedentQueries.join(", ")}`
+  )
+  assert.ok(
+    apiClient.precedentQueries.length >= 3,
+    `expected fallback attempts after raw search, got ${apiClient.precedentQueries.length}: ${apiClient.precedentQueries.join(", ")}`
   )
 }
 

--- a/test/test-chain-search-detail-integration.cjs
+++ b/test/test-chain-search-detail-integration.cjs
@@ -80,6 +80,22 @@ function makeApiClient() {
   }
 }
 
+function makePrecedentFailureApiClient() {
+  return {
+    async searchLaw() {
+      return noLawXml()
+    },
+    async fetchApi(request) {
+      if (request.target === "aiSearch") return noAiLawXml()
+      if (request.target === "expc") return noInterpretationXml()
+      if (request.target === "prec" && request.endpoint === "lawSearch.do") {
+        throw new Error("precedent API down")
+      }
+      throw new Error(`unexpected API request: ${JSON.stringify(request)}`)
+    },
+  }
+}
+
 async function testChainFullResearchFetchesTopTwoPrecedentDetails(chainFullResearch) {
   const apiClient = makeApiClient()
 
@@ -95,6 +111,22 @@ async function testChainFullResearchFetchesTopTwoPrecedentDetails(chainFullResea
   assert.ok(text.includes("상세 판례 111"), text)
   assert.ok(text.includes("상세 판례 222"), text)
   assert.ok(!text.includes("상세 판례 333"), text)
+}
+
+async function testChainFullResearchSurvivesPrecedentSearchFailure(chainFullResearch) {
+  const apiClient = makePrecedentFailureApiClient()
+
+  const result = await chainFullResearch(apiClient, {
+    query: "청약철회 청구",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.ok(!result.isError, text)
+  assert.ok(text.includes("═══ 종합 리서치: 청약철회 청구 ═══"), text)
+  assert.ok(text.includes("▶ 관련 판례 [NOT_FOUND / FAILED]"), text)
+  assert.ok(text.includes("precedent API down"), text)
+  assert.ok(text.includes("▶ 법령 해석례"), text)
 }
 
 async function testDocumentReviewFetchesTopTwoPrecedentDetailsTotal(chainDocumentReview) {
@@ -113,10 +145,27 @@ async function testDocumentReviewFetchesTopTwoPrecedentDetailsTotal(chainDocumen
   assert.ok(!text.includes("상세 판례 333"), text)
 }
 
+async function testDocumentReviewSurvivesPrecedentSearchFailure(chainDocumentReview) {
+  const apiClient = makePrecedentFailureApiClient()
+
+  const result = await chainDocumentReview(apiClient, {
+    text: "제1조 환불은 어떠한 경우에도 불가하다.",
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.ok(!result.isError, text)
+  assert.ok(text.includes("▶ 문서 리스크 분석"), text)
+  assert.ok(text.includes("▶ 판례 검색 실패"), text)
+  assert.ok(text.includes("precedent API down"), text)
+}
+
 async function main() {
   const { chainFullResearch, chainDocumentReview } = await import("../build/tools/chains.js")
   await testChainFullResearchFetchesTopTwoPrecedentDetails(chainFullResearch)
+  await testChainFullResearchSurvivesPrecedentSearchFailure(chainFullResearch)
   await testDocumentReviewFetchesTopTwoPrecedentDetailsTotal(chainDocumentReview)
+  await testDocumentReviewSurvivesPrecedentSearchFailure(chainDocumentReview)
   console.log("chain search detail integration tests passed")
 }
 

--- a/test/test-compact-query-planner.cjs
+++ b/test/test-compact-query-planner.cjs
@@ -2,20 +2,6 @@
 
 const assert = require("assert")
 
-const AI_LAW_TEXT = [
-  "지능형 법령검색 결과 (법령조문, 2건):",
-  "",
-  "전자상거래 등에서의 소비자보호에 관한 법률",
-  "   제0017조 (청약철회등)",
-  "   소비자는 통신판매업자와 재화등의 구매에 관한 계약을 체결한 경우 청약철회등을 할 수 있다.",
-  "   시행: 2026.01.20 | 공정거래위원회",
-  "",
-  "고용정책 기본법",
-  "   제0007조 (취업기회의 균등한 보장)",
-  "   사업주는 모집과 채용에서 고용 차별이 발생하지 않도록 하여야 한다.",
-  "   시행: 2026.01.01 | 고용노동부",
-].join("\n")
-
 const AI_LAW_ARTICLES = [
   {
     lawName: "콘텐츠산업 진흥법",
@@ -33,19 +19,16 @@ const AI_LAW_ARTICLES = [
   },
 ]
 
-async function testUsesStructuredAiLawSignals() {
+async function testIgnoresRenderedAiLawText() {
   const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
 
   const candidates = buildCompactLegalQueries({
     originalQuery: "중고거래로 옷을 팔았는데 환불해달라고 합니다",
-    aiLawText: AI_LAW_TEXT,
+    aiLawText: "   제0017조 (청약철회등)",
     max: 10,
   }).map((candidate) => candidate.query)
 
-  assert.ok(candidates.includes("청약철회"), candidates.join(", "))
-  assert.ok(candidates.includes("전자상거래 등에서의 소비자보호에 관한 법률 청약철회"), candidates.join(", "))
-  assert.ok(candidates.includes("취업기회의 균등한 보장"), candidates.join(", "))
-  assert.ok(candidates.includes("고용정책 기본법 취업기회의 균등한 보장"), candidates.join(", "))
+  assert.deepStrictEqual(candidates, [])
 }
 
 async function testUsesRawAiLawArticleSignalsBeforeFormattedText() {
@@ -102,7 +85,13 @@ async function testDoesNotExtractBodySuffixKeywords() {
 
   const candidates = buildCompactLegalQueries({
     originalQuery: "채용 과정에서 불합리한 대우를 받았습니다",
-    aiLawText: AI_LAW_TEXT,
+    aiLawArticles: [{
+      lawName: "고용정책 기본법",
+      articleNo: "0007",
+      articleTitle: "취업기회의 균등한 보장",
+      articleContent: "사업주는 모집과 채용에서 고용 차별이 발생하지 않도록 하여야 한다.",
+      sourceIndex: 0,
+    }],
     max: 10,
   }).map((candidate) => candidate.query)
 
@@ -128,7 +117,7 @@ async function testDoesNotCreateCandidatesFromArticleContentReferences() {
   assert.ok(!candidates.includes("청약철회"), candidates.join(", "))
 }
 
-async function testUsesRetrySuggestionsAndRouterCandidates() {
+async function testUsesRouterCandidatesWithoutRenderedRetryText() {
   const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
 
   const candidates = buildCompactLegalQueries({
@@ -141,15 +130,314 @@ async function testUsesRetrySuggestionsAndRouterCandidates() {
     max: 10,
   }).map((candidate) => candidate.query)
 
-  assert.deepStrictEqual(candidates.slice(0, 4), [
-    "중고거래",
-    "중고거래 옷",
+  assert.deepStrictEqual(candidates.slice(0, 2), [
     "청약철회",
     "전자상거래 청약철회",
   ])
+  assert.ok(!candidates.includes("중고거래"), candidates.join(", "))
 }
 
-async function testFiltersWeakCandidates() {
+async function testPrioritizesCaseNumberAndOriginalQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "프리랜서 근로자성 판례를 찾아줘",
+    includeOriginal: true,
+    caseNumber: "2024다12345",
+    aiLawArticles: [{
+      lawName: "근로기준법",
+      articleNo: "0002",
+      articleTitle: "근로자 정의",
+      articleContent: "근로자란 직업의 종류와 관계없이 임금을 목적으로 사업이나 사업장에 근로를 제공하는 사람을 말한다.",
+      sourceIndex: 0,
+    }],
+    max: 10,
+  })
+
+  assert.deepStrictEqual(candidates.slice(0, 2).map((candidate) => candidate.query), [
+    "2024다12345",
+    "프리랜서 근로자성",
+  ])
+  assert.strictEqual(candidates[0].source, "case_number")
+  assert.strictEqual(candidates[1].source, "original_query")
+  assert.ok(
+    candidates.findIndex((candidate) => candidate.source === "original_query") <
+      candidates.findIndex((candidate) => candidate.source === "ai_law_article_title"),
+    candidates.map((candidate) => `${candidate.source}:${candidate.query}`).join(", ")
+  )
+}
+
+async function testBuildsReducedKeywordsFromOriginalQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "중고거래 옷 구매자 단순 변심 환불 의무",
+    includeOriginal: true,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.strictEqual(queries[0], "중고거래 옷 구매자 단순 변심 환불 의무")
+  assert.ok(!queries.includes("중고거래"), queries.join(", "))
+  assert.ok(candidates.some((candidate) => (
+    candidate.source === "original_keyword" &&
+    candidate.query.split(/\s+/).length >= 2
+  )), candidates.map((candidate) => `${candidate.source}:${candidate.query}`).join(", "))
+  assert.strictEqual(candidates[1].source, "original_keyword")
+}
+
+async function testBuildsAxisCombinedKeywordsForTaxFraudQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "사기 행위에 의해 부과된 양도소득세 취소가 가능한가?",
+    includeOriginal: true,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.ok(queries.includes("양도소득세 사기"), queries.join(", "))
+  const combinedIndex = queries.indexOf("양도소득세 사기")
+  const singleFraudIndex = queries.indexOf("사기")
+  assert.ok(
+    singleFraudIndex === -1 || combinedIndex < singleFraudIndex,
+    candidates.map((candidate) => `${candidate.source}:${candidate.query}:${candidate.score}`).join(", ")
+  )
+
+  const combined = candidates[combinedIndex]
+  assert.strictEqual(combined.source, "original_keyword")
+  assert.deepStrictEqual(combined.validationTermGroups[0], ["양도소득세", "소득세", "조세", "과세"])
+  for (const term of ["사기", "사기행위", "부정한 행위", "허위"]) {
+    assert.ok(combined.validationTermGroups[1].includes(term), combined.validationTermGroups[1].join(", "))
+  }
+}
+
+async function testBuildsAxisCombinedKeywordsForToolArgumentQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "사기 행위에 의해 부과된 양도소득세 취소 가능 여부 및 절차",
+    includeOriginal: true,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.ok(queries.includes("양도소득세 사기"), queries.join(", "))
+  assert.ok(
+    queries.some((query) => query.includes("소득세") && query.includes("양도소득세") && query.includes("사기")),
+    queries.join(", ")
+  )
+  assert.ok(!queries.slice(0, 5).includes("사기"), queries.join(", "))
+  assert.ok(!queries.includes("양도소득세 가능한"), queries.join(", "))
+}
+
+async function testBuildsAxisCombinedKeywordsForConstructionDefectQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "건설공사 준공 후 하자보수와 지체상금 판례 찾아줘",
+    includeOriginal: true,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.ok(queries.includes("건설공사 하자보수"), queries.join(", "))
+  assert.ok(
+    queries.some((query) => query.includes("건설공사") && query.includes("지체상금")),
+    queries.join(", ")
+  )
+  assert.ok(!queries.slice(0, 5).includes("하자"), queries.join(", "))
+
+  const combined = candidates[queries.indexOf("건설공사 하자보수")]
+  assert.deepStrictEqual(combined.validationTermGroups[0], ["건설공사", "건설", "공사", "도급", "하도급"])
+  for (const term of ["하자보수", "하자", "하자담보책임", "부실시공"]) {
+    assert.ok(combined.validationTermGroups[1].includes(term), combined.validationTermGroups[1].join(", "))
+  }
+
+  const delayCombined = candidates.find((candidate) => candidate.query === "건설공사 지체상금")
+  assert.ok(delayCombined, queries.join(", "))
+  assert.ok(delayCombined.validationTermGroups[1].includes("공기지연"), delayCombined.validationTermGroups[1].join(", "))
+}
+
+async function testBuildsAxisCombinedKeywordsForConstructionDelayQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "건설공사 공기지연으로 인한 지체상금 판례",
+    includeOriginal: true,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.ok(queries.includes("건설공사 공기지연"), queries.join(", "))
+  const combined = candidates[queries.indexOf("건설공사 공기지연")]
+  for (const term of ["공기지연", "지체상금", "지연손해금", "공사지연", "공기연장"]) {
+    assert.ok(combined.validationTermGroups[1].includes(term), combined.validationTermGroups[1].join(", "))
+  }
+}
+
+async function testBuildsAxisCombinedKeywordsForConstructionPaymentQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "하도급 공사비 미지급 원청 책임 판례",
+    includeOriginal: true,
+    max: 10,
+  })
+  const queries = candidates.map((candidate) => candidate.query)
+
+  assert.ok(queries.includes("하도급 공사비"), queries.join(", "))
+  assert.ok(!queries.includes("하도급 도급"), queries.join(", "))
+  const combined = candidates[queries.indexOf("하도급 공사비")]
+  assert.ok(combined.validationTermGroups[0].includes("하도급"), combined.validationTermGroups[0].join(", "))
+  for (const term of ["공사비", "공사대금", "기성금", "추가공사비"]) {
+    assert.ok(combined.validationTermGroups[1].includes(term), combined.validationTermGroups[1].join(", "))
+  }
+}
+
+async function testDoesNotBuildReducedKeywordsForLongNarrative() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "공원에서 풍경 사진을 찍어서 SNS에 올리려고 하는데 사진 구석에 모르는 사람 얼굴이 작게 찍혀 있었다면 허락이 필요한가요",
+    includeOriginal: true,
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.ok(!candidates.includes("공원"), candidates.join(", "))
+  assert.ok(!candidates.includes("공원 풍경"), candidates.join(", "))
+}
+
+async function testPrioritizesDocumentHintsAboveAiLawTitles() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "계약서 조항 검토",
+    includeOriginal: true,
+    documentHints: ["임대차 보증금 반환 판례"],
+    aiLawArticles: [{
+      lawName: "주택임대차보호법",
+      articleNo: "0003",
+      articleTitle: "대항력 등",
+      articleContent: "임차인은 주택의 인도와 주민등록을 마친 때에는 그 다음 날부터 제삼자에 대하여 효력이 생긴다.",
+      sourceIndex: 0,
+    }],
+    max: 10,
+  })
+
+  assert.deepStrictEqual(candidates.slice(0, 2).map((candidate) => candidate.query), [
+    "계약서 조항 검토",
+    "임대차 보증금 반환 판례",
+  ])
+  assert.ok(
+    candidates.findIndex((candidate) => candidate.source === "document_hint") <
+      candidates.findIndex((candidate) => candidate.source === "ai_law_article_title"),
+    candidates.map((candidate) => `${candidate.source}:${candidate.query}`).join(", ")
+  )
+}
+
+async function testDetectsCaseNumberFromOriginalQuery() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "대법원 2023다123456 판결 찾아줘",
+    max: 5,
+  })
+
+  assert.strictEqual(candidates[0].query, "2023다123456")
+  assert.strictEqual(candidates[0].source, "case_number")
+  assert.strictEqual(candidates.filter((candidate) => candidate.query === "2023다123456").length, 1)
+}
+
+async function testKeepsBareCaseNumberCandidate() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "2023다123456",
+    includeOriginal: true,
+    max: 5,
+  })
+
+  assert.strictEqual(candidates[0].query, "2023다123456")
+  assert.strictEqual(candidates[0].source, "case_number")
+}
+
+async function testDoesNotClassifyKoreanDateAsCaseNumber() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "2024년 5월 양도소득세 처분 취소",
+    includeOriginal: true,
+    max: 5,
+  })
+
+  assert.ok(
+    !candidates.some((candidate) => candidate.source === "case_number"),
+    candidates.map((candidate) => `${candidate.source}:${candidate.query}`).join(", ")
+  )
+}
+
+async function testDoesNotMakeEveryTerminalDeungBodySearch() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "성평등 판례 찾아줘",
+    aiLawArticles: [{
+      lawName: "양성평등기본법",
+      articleNo: "0003",
+      articleTitle: "성평등",
+      articleContent: "성평등은 모든 영역에서 평등한 책임과 권리를 공유하는 것을 말한다.",
+      sourceIndex: 0,
+    }],
+    max: 10,
+  })
+
+  const equality = candidates.find((candidate) => candidate.query === "성평등")
+  assert.ok(equality, candidates.map((candidate) => candidate.query).join(", "))
+  assert.strictEqual(equality.search, 1)
+  assert.ok(
+    !candidates.some((candidate) => candidate.query === "성평 등" && candidate.search === 2),
+    candidates.map((candidate) => `${candidate.query}:${candidate.search}`).join(", ")
+  )
+}
+
+async function testKeepsSpacedTerminalDeungBodySearchForAiLawTitle() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "중고거래 환불",
+    aiLawArticles: [{
+      lawName: "콘텐츠산업 진흥법",
+      articleNo: "0027",
+      articleTitle: "청약철회 등",
+      articleContent: "청약철회 등 계약 해제 관련 표시를 하여야 한다.",
+      sourceIndex: 0,
+    }],
+    max: 10,
+  })
+
+  assert.ok(
+    candidates.some((candidate) => candidate.query === "청약철회 등" && candidate.search === 2),
+    candidates.map((candidate) => `${candidate.query}:${candidate.search}`).join(", ")
+  )
+}
+
+async function testOriginalQueryDoesNotUseRenderedFailureSuggestions() {
+  const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
+
+  const candidates = buildCompactLegalQueries({
+    originalQuery: "근로자성 판례 찾아줘",
+    includeOriginal: true,
+    failedSearchText: '재시도 제안: "근로자" 또는 "사용종속관계"',
+    max: 10,
+  }).map((candidate) => candidate.query)
+
+  assert.deepStrictEqual(candidates, [
+    "근로자성",
+  ])
+}
+
+async function testDoesNotMineCandidatesFromRenderedFailureText() {
   const { buildCompactLegalQueries } = await import("../build/tools/compact-query-planner.js")
 
   const longCandidate = "가".repeat(41)
@@ -159,17 +447,32 @@ async function testFiltersWeakCandidates() {
     max: 10,
   }).map((candidate) => candidate.query)
 
-  assert.deepStrictEqual(candidates, ["청약철회"])
+  assert.deepStrictEqual(candidates, [])
 }
 
 async function main() {
-  await testUsesStructuredAiLawSignals()
+  await testIgnoresRenderedAiLawText()
   await testUsesRawAiLawArticleSignalsBeforeFormattedText()
   await testDoesNotDestructivelyStripEqualityTitle()
   await testDoesNotExtractBodySuffixKeywords()
   await testDoesNotCreateCandidatesFromArticleContentReferences()
-  await testUsesRetrySuggestionsAndRouterCandidates()
-  await testFiltersWeakCandidates()
+  await testUsesRouterCandidatesWithoutRenderedRetryText()
+  await testPrioritizesCaseNumberAndOriginalQuery()
+  await testBuildsReducedKeywordsFromOriginalQuery()
+  await testBuildsAxisCombinedKeywordsForTaxFraudQuery()
+  await testBuildsAxisCombinedKeywordsForToolArgumentQuery()
+  await testBuildsAxisCombinedKeywordsForConstructionDefectQuery()
+  await testBuildsAxisCombinedKeywordsForConstructionDelayQuery()
+  await testBuildsAxisCombinedKeywordsForConstructionPaymentQuery()
+  await testDoesNotBuildReducedKeywordsForLongNarrative()
+  await testPrioritizesDocumentHintsAboveAiLawTitles()
+  await testDetectsCaseNumberFromOriginalQuery()
+  await testKeepsBareCaseNumberCandidate()
+  await testDoesNotClassifyKoreanDateAsCaseNumber()
+  await testDoesNotMakeEveryTerminalDeungBodySearch()
+  await testKeepsSpacedTerminalDeungBodySearchForAiLawTitle()
+  await testOriginalQueryDoesNotUseRenderedFailureSuggestions()
+  await testDoesNotMineCandidatesFromRenderedFailureText()
   console.log("compact query planner tests passed")
 }
 

--- a/test/test-precedent-evidence.cjs
+++ b/test/test-precedent-evidence.cjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+function structuredResult(ids) {
+  return {
+    originalArgs: { query: "위약금 감액", display: 10, page: 1 },
+    totalCount: ids.length,
+    page: 1,
+    hits: ids.map((id) => ({
+      id,
+      title: `검색 판례 ${id}`,
+      caseNumber: `2024다${id}`,
+      court: "대법원",
+      date: "20240101",
+      decisionType: "판결",
+      searchMode: 1,
+    })),
+    attempts: [],
+    fallbackUsed: false,
+  }
+}
+
+function precedentDetailJson(id) {
+  return JSON.stringify({
+    PrecService: {
+      사건명: `상세 판례 ${id}`,
+      사건번호: `2024다${id}`,
+      법원명: "대법원",
+      선고일자: "20240101",
+      사건종류명: "민사",
+      판결유형: "판결",
+      판시사항: `판시사항 ${id}`,
+      판결요지: `판결요지 ${id}`,
+      참조조문: "민법 제398조",
+      판례내용: `전문 ${id}`,
+    },
+  })
+}
+
+function makeApiClient(resolver) {
+  const detailIds = []
+  return {
+    detailIds,
+    async fetchApi(request) {
+      if (request.target === "prec" && request.endpoint === "lawService.do") {
+        const id = String(request.extraParams?.ID || "")
+        detailIds.push(id)
+        return resolver(id, request)
+      }
+      throw new Error(`unexpected API request: ${JSON.stringify(request)}`)
+    },
+  }
+}
+
+async function testFetchesTopTwoStructuredHits() {
+  const { fetchPrecedentEvidence } = await import("../build/tools/precedent-evidence.js")
+  const apiClient = makeApiClient((id) => precedentDetailJson(id))
+
+  const result = await fetchPrecedentEvidence(apiClient, structuredResult(["111", "222", "333"]), {
+    apiKey: "test",
+  })
+
+  assert.deepStrictEqual(apiClient.detailIds.slice(0, 2), ["111", "222"])
+  assert.strictEqual(result.isError, false)
+  assert.strictEqual(result.items.length, 2)
+  assert.ok(result.text.includes("자동 상세조회: search_precedents -> get_precedent_text (상위 2건, full=false)"), result.text)
+  assert.ok(result.text.includes("[111] 검색 판례 111"), result.text)
+  assert.ok(result.text.includes("상세 판례 111"), result.text)
+  assert.ok(result.text.includes("상세 판례 222"), result.text)
+  assert.ok(!result.text.includes("상세 판례 333"), result.text)
+}
+
+async function testPreservesPartialDetailFailure() {
+  const { fetchPrecedentEvidence } = await import("../build/tools/precedent-evidence.js")
+  const apiClient = makeApiClient((id) => {
+    if (id === "222") throw new Error("detail unavailable")
+    return precedentDetailJson(id)
+  })
+
+  const result = await fetchPrecedentEvidence(apiClient, structuredResult(["111", "222"]), {
+    apiKey: "test",
+  })
+
+  assert.deepStrictEqual(apiClient.detailIds.slice(0, 2), ["111", "222"])
+  assert.strictEqual(result.isError, false)
+  assert.strictEqual(result.items.length, 2)
+  assert.strictEqual(result.items[0].isError, false)
+  assert.strictEqual(result.items[1].isError, true)
+  assert.ok(result.items[1].detailError.includes("detail unavailable"))
+  assert.ok(result.text.includes("상세 판례 111"), result.text)
+  assert.ok(result.text.includes("상세조회 실패"), result.text)
+}
+
+async function testCapsDetailLimit() {
+  const { fetchPrecedentEvidence } = await import("../build/tools/precedent-evidence.js")
+  const apiClient = makeApiClient((id) => precedentDetailJson(id))
+
+  const result = await fetchPrecedentEvidence(
+    apiClient,
+    structuredResult(["101", "102", "103", "104", "105", "106"]),
+    { detailLimit: 50, apiKey: "test" }
+  )
+
+  assert.deepStrictEqual(apiClient.detailIds, ["101", "102", "103", "104", "105"])
+  assert.strictEqual(result.items.length, 5)
+}
+
+async function testReturnsNullForNoHits() {
+  const { fetchPrecedentEvidence } = await import("../build/tools/precedent-evidence.js")
+  const apiClient = makeApiClient((id) => precedentDetailJson(id))
+
+  const result = await fetchPrecedentEvidence(apiClient, structuredResult([]), {
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result, null)
+  assert.deepStrictEqual(apiClient.detailIds, [])
+}
+
+async function testValidationRequiresAllAxisGroups() {
+  const { validatePrecedentSearchResult } = await import("../build/tools/precedent-evidence.js")
+  const apiClient = makeApiClient((id) => precedentDetailJson(id))
+
+  const input = {
+    originalArgs: { query: "사기 행위에 의해 부과된 양도소득세 취소가 가능한가?", display: 5, page: 1 },
+    attempt: {
+      query: "양도소득세 사기",
+      search: 1,
+      reason: "original_keyword",
+      totalCount: 1,
+      hitCount: 1,
+      success: true,
+      requiresResultValidation: true,
+      validationTermGroups: [
+        ["양도소득세", "소득세", "조세", "과세"],
+        ["사기", "사기행위", "부정한행위", "허위"],
+      ],
+    },
+    hits: [{
+      id: "999",
+      title: "특정경제범죄가중처벌등에관한법률위반(사기)",
+      caseNumber: "2025도999",
+      court: "대법원",
+      date: "20250101",
+      decisionType: "판결",
+      searchMode: 1,
+    }],
+  }
+
+  const accepted = await validatePrecedentSearchResult(apiClient, input, { apiKey: "test" })
+
+  assert.strictEqual(accepted, false)
+}
+
+async function testValidationAcceptsSeparatedAxisTerms() {
+  const { validatePrecedentSearchResult } = await import("../build/tools/precedent-evidence.js")
+  const apiClient = makeApiClient((id) => precedentDetailJson(id))
+
+  const input = {
+    originalArgs: { query: "사기 행위에 의해 부과된 양도소득세 취소가 가능한가?", display: 5, page: 1 },
+    attempt: {
+      query: "양도소득세 사기",
+      search: 1,
+      reason: "original_keyword",
+      totalCount: 1,
+      hitCount: 1,
+      success: true,
+      requiresResultValidation: true,
+      validationTermGroups: [
+        ["양도소득세", "소득세", "조세", "과세"],
+        ["사기", "사기행위", "부정한행위", "허위"],
+      ],
+    },
+    hits: [{
+      id: "998",
+      title: "허위계약서를 작성하는 방법으로 양도소득세 신고를 한 것은 사기 기타 부정한 행위에 해당함",
+      caseNumber: "2025구합998",
+      court: "서울행정법원",
+      date: "20250101",
+      decisionType: "판결",
+      searchMode: 1,
+    }],
+  }
+
+  const accepted = await validatePrecedentSearchResult(apiClient, input, { apiKey: "test" })
+
+  assert.strictEqual(accepted, true)
+  assert.deepStrictEqual(apiClient.detailIds, [])
+}
+
+async function main() {
+  await testFetchesTopTwoStructuredHits()
+  await testPreservesPartialDetailFailure()
+  await testCapsDetailLimit()
+  await testReturnsNullForNoHits()
+  await testValidationRequiresAllAxisGroups()
+  await testValidationAcceptsSeparatedAxisTerms()
+  console.log("precedent evidence tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/test-precedent-search-core.cjs
+++ b/test/test-precedent-search-core.cjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+function precedentXml(items) {
+  const rows = items.map((item) => [
+    "<prec>",
+    `<판례일련번호>${item.id}</판례일련번호>`,
+    `<사건명>${item.title}</사건명>`,
+    `<사건번호>${item.caseNumber || "2024다12345"}</사건번호>`,
+    `<법원명>${item.court || "대법원"}</법원명>`,
+    `<선고일자>${item.date || "20240101"}</선고일자>`,
+    `<판결유형>${item.type || "판결"}</판결유형>`,
+    `<판례상세링크>${item.link || `https://example.test/${item.id}`}</판례상세링크>`,
+    "</prec>",
+  ].join("")).join("")
+  return `<PrecSearch><totalCnt>${items.length}</totalCnt><page>1</page>${rows}</PrecSearch>`
+}
+
+function noPrecedentXml() {
+  return "<PrecSearch><totalCnt>0</totalCnt><page>1</page></PrecSearch>"
+}
+
+function makeApiClient(resolver) {
+  const requests = []
+  return {
+    requests,
+    async fetchApi(request) {
+      requests.push(request)
+      return resolver(request)
+    },
+  }
+}
+
+async function testReturnsStructuredOriginalQueryResult() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient(() => precedentXml([{ id: "100", title: "근로자성 사건" }]))
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "프리랜서 근로자성",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result.hits.length, 1)
+  assert.strictEqual(result.hits[0].id, "100")
+  assert.strictEqual(result.hits[0].title, "근로자성 사건")
+  assert.strictEqual(result.hits[0].sourceQuery, "프리랜서 근로자성")
+  assert.strictEqual(result.hits[0].searchMode, 1)
+  assert.strictEqual(result.attempts.length, 1)
+  assert.strictEqual(result.attempts[0].reason, "original_query")
+  assert.strictEqual(apiClient.requests[0].extraParams.query, "프리랜서 근로자성")
+  assert.strictEqual(apiClient.requests[0].extraParams.display, "5")
+}
+
+async function testFallsBackToBodySearchForConceptQuery() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient((request) => {
+    if (request.extraParams.search === "2") {
+      return precedentXml([{ id: "200", title: "본문 근로자성 사건" }])
+    }
+    return noPrecedentXml()
+  })
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "근로자성",
+    display: 3,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result.fallbackUsed, true)
+  assert.strictEqual(result.hits[0].id, "200")
+  assert.deepStrictEqual(result.attempts.map((attempt) => `${attempt.reason}:${attempt.search}`), [
+    "original_query:1",
+    "body_search:2",
+  ])
+}
+
+async function testUsesExplicitCaseNumberBeforeQueryFallback() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient((request) => {
+    if (request.extraParams.nb === "2024다12345") {
+      return precedentXml([{ id: "300", title: "사건번호 사건", caseNumber: "2024다12345" }])
+    }
+    return noPrecedentXml()
+  })
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "근로자성 판례",
+    caseNumber: "2024다12345",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result.hits[0].id, "300")
+  assert.strictEqual(result.attempts[0].reason, "case_number")
+  assert.strictEqual(apiClient.requests[0].extraParams.nb, "2024다12345")
+  assert.strictEqual(apiClient.requests[0].extraParams.query, undefined)
+}
+
+async function testMarksDateRelaxedResultsOutOfRequestedRange() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient(() => precedentXml([
+    { id: "400", title: "과거 판례", date: "20190101" },
+  ]))
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "보증금 반환",
+    fromDate: "20240101",
+    toDate: "20241231",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result.hits.length, 1)
+  assert.strictEqual(result.hits[0].outOfRequestedDateRange, true)
+  assert.strictEqual(result.successfulAttempt.outOfRequestedDateRange, true)
+  assert.strictEqual(result.fallbackUsed, true)
+  assert.ok(result.attempts.some((attempt) => attempt.reason === "date_relaxed"))
+}
+
+async function testDateFilteredTotalCountMatchesRenderedHits() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient(() => precedentXml([
+    { id: "410", title: "범위 내 판례", date: "20240101" },
+    { id: "411", title: "범위 밖 판례", date: "20190101" },
+  ]))
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "보증금 반환",
+    fromDate: "20240101",
+    toDate: "20241231",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result.hits.length, 1)
+  assert.strictEqual(result.totalCount, 1)
+  assert.strictEqual(result.hits[0].id, "410")
+}
+
+async function testReturnsAttemptsForNoResult() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient(() => noPrecedentXml())
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "없는 판례",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+
+  assert.strictEqual(result.hits.length, 0)
+  assert.strictEqual(result.totalCount, 0)
+  assert.ok(result.attempts.length >= 1)
+  assert.ok(result.attempts.every((attempt) => attempt.success === false))
+}
+
+async function testPropagatesApiFailureWithoutFallback() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient(() => {
+    throw new Error("invalid api key")
+  })
+
+  await assert.rejects(
+    () => searchPrecedentsStructured(apiClient, {
+      query: "근로자성",
+      display: 5,
+      page: 1,
+      apiKey: "test",
+    }),
+    /invalid api key/
+  )
+  assert.strictEqual(apiClient.requests.length, 1)
+}
+
+async function testCanDisableFallbackForExactReferenceSearch() {
+  const { searchPrecedentsStructured } = await import("../build/tools/precedent-search-core.js")
+  const apiClient = makeApiClient((request) => {
+    if (request.extraParams.query === "양도소득세 사기") {
+      return precedentXml([{ id: "900", title: "fallback result" }])
+    }
+    return noPrecedentXml()
+  })
+
+  const result = await searchPrecedentsStructured(apiClient, {
+    query: "소득세법 제101조",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  }, {
+    fallbackPolicy: "none",
+  })
+
+  assert.strictEqual(result.hits.length, 0)
+  assert.deepStrictEqual(apiClient.requests.map((request) => request.extraParams.query), ["소득세법 제101조"])
+}
+
+async function main() {
+  await testReturnsStructuredOriginalQueryResult()
+  await testFallsBackToBodySearchForConceptQuery()
+  await testUsesExplicitCaseNumberBeforeQueryFallback()
+  await testMarksDateRelaxedResultsOutOfRequestedRange()
+  await testDateFilteredTotalCountMatchesRenderedHits()
+  await testReturnsAttemptsForNoResult()
+  await testPropagatesApiFailureWithoutFallback()
+  await testCanDisableFallbackForExactReferenceSearch()
+  console.log("precedent search core tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/test-precedent-search-scope.cjs
+++ b/test/test-precedent-search-scope.cjs
@@ -6,6 +6,34 @@ function noPrecedentXml() {
   return "<PrecSearch><totalCnt>0</totalCnt><page>1</page></PrecSearch>"
 }
 
+function precedentXml(items) {
+  const rows = items.map((item) => [
+    "<prec>",
+    `<판례일련번호>${item.id}</판례일련번호>`,
+    `<사건명>${item.title}</사건명>`,
+    `<사건번호>${item.caseNumber || "2024다12345"}</사건번호>`,
+    `<법원명>${item.court || "대법원"}</법원명>`,
+    `<선고일자>${item.date || "20240101"}</선고일자>`,
+    `<판결유형>${item.type || "판결"}</판결유형>`,
+    "</prec>",
+  ].join("")).join("")
+  return `<PrecSearch><totalCnt>${items.length}</totalCnt><page>1</page>${rows}</PrecSearch>`
+}
+
+function precedentDetailJson(title, body) {
+  return JSON.stringify({
+    PrecService: {
+      사건명: title,
+      사건번호: "2024다12345",
+      법원명: "대법원",
+      선고일자: "20240101",
+      사건종류명: "민사",
+      판결유형: "판결",
+      판례내용: body,
+    },
+  })
+}
+
 async function testPassesSearchScope() {
   const { searchPrecedents } = await import("../build/tools/precedents.js")
   const calls = []
@@ -47,9 +75,46 @@ async function testKeepsDefaultSearchScopeImplicit() {
   assert.ok(!("search" in calls[0].extraParams), JSON.stringify(calls[0].extraParams))
 }
 
+async function testDirectSearchValidatesAxisFallback() {
+  const { searchPrecedents } = await import("../build/tools/precedents.js")
+  const calls = []
+  const apiClient = {
+    async fetchApi(request) {
+      calls.push(request)
+      if (request.target === "prec" && request.endpoint === "lawSearch.do") {
+        const query = request.extraParams?.query || ""
+        if (query === "양도소득세 사기") {
+          return precedentXml([{
+            id: "999",
+            title: "특정경제범죄가중처벌등에관한법률위반(사기)",
+          }])
+        }
+        return noPrecedentXml()
+      }
+      if (request.target === "prec" && request.endpoint === "lawService.do") {
+        return precedentDetailJson("특정경제범죄가중처벌등에관한법률위반(사기)", "일반 형사 사기 사건")
+      }
+      throw new Error(`unexpected API request: ${JSON.stringify(request)}`)
+    },
+  }
+
+  const result = await searchPrecedents(apiClient, {
+    query: "사기 행위에 의해 부과된 양도소득세 취소가 가능한가?",
+    display: 5,
+    page: 1,
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.strictEqual(result.isError, true)
+  assert.ok(text.includes("[NOT_FOUND]"), text)
+  assert.ok(calls.some((request) => request.endpoint === "lawService.do"), "expected detail validation request")
+}
+
 async function main() {
   await testPassesSearchScope()
   await testKeepsDefaultSearchScopeImplicit()
+  await testDirectSearchValidatesAxisFallback()
   console.log("precedent search scope tests passed")
 }
 

--- a/test/test-search-decisions-precedent-include-text.cjs
+++ b/test/test-search-decisions-precedent-include-text.cjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+const assert = require("assert")
+
+function precedentXml(ids) {
+  return [
+    "<PrecSearch>",
+    `<totalCnt>${ids.length}</totalCnt>`,
+    "<page>1</page>",
+    ...ids.map((id) => [
+      "<prec>",
+      `<판례일련번호>${id}</판례일련번호>`,
+      `<사건명>검색 판례 ${id}</사건명>`,
+      `<사건번호>2024다${id}</사건번호>`,
+      "<법원명>대법원</법원명>",
+      "<선고일자>20240101</선고일자>",
+      "<판결유형>판결</판결유형>",
+      `<판례상세링크>https://example.test/prec/${id}</판례상세링크>`,
+      "</prec>",
+    ].join("")),
+    "</PrecSearch>",
+  ].join("")
+}
+
+function precedentDetailJson(id) {
+  return JSON.stringify({
+    PrecService: {
+      사건명: `상세 판례 ${id}`,
+      사건번호: `2024다${id}`,
+      법원명: "대법원",
+      선고일자: "20240101",
+      사건종류명: "민사",
+      판결유형: "판결",
+      판시사항: `판시사항 ${id}`,
+      판결요지: `판결요지 ${id}`,
+      참조조문: "민법 제398조",
+      판례내용: `전문 ${id}`,
+    },
+  })
+}
+
+function makeApiClient() {
+  const searchRequests = []
+  const detailIds = []
+  return {
+    searchRequests,
+    detailIds,
+    async fetchApi(request) {
+      if (request.target === "prec" && request.endpoint === "lawSearch.do") {
+        searchRequests.push(request)
+        return precedentXml(["111", "222", "333"])
+      }
+      if (request.target === "prec" && request.endpoint === "lawService.do") {
+        const id = String(request.extraParams?.ID || "")
+        detailIds.push(id)
+        return precedentDetailJson(id)
+      }
+      throw new Error(`unexpected API request: ${JSON.stringify(request)}`)
+    },
+  }
+}
+
+async function testDefaultPrecedentSearchRemainsListOnly() {
+  const { searchDecisions } = await import("../build/tools/unified-decisions.js")
+  const apiClient = makeApiClient()
+
+  const result = await searchDecisions(apiClient, {
+    domain: "precedent",
+    query: "위약금 감액",
+    display: 3,
+    page: 1,
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.detailIds, [])
+  assert.ok(text.includes("[111] 검색 판례 111"), text)
+  assert.ok(!text.includes("자동 상세조회"), text)
+}
+
+async function testIncludeTextFetchesBoundedPrecedentDetails() {
+  const { searchDecisions } = await import("../build/tools/unified-decisions.js")
+  const apiClient = makeApiClient()
+
+  const result = await searchDecisions(apiClient, {
+    domain: "precedent",
+    query: "위약금 감액",
+    display: 3,
+    page: 1,
+    options: {
+      includeText: true,
+      detailLimit: 2,
+    },
+    apiKey: "test",
+  })
+  const text = result.content?.[0]?.text || ""
+
+  assert.deepStrictEqual(apiClient.detailIds, ["111", "222"])
+  assert.ok(text.includes("판례 검색 결과"), text)
+  assert.ok(text.includes("[111] 검색 판례 111"), text)
+  assert.ok(text.includes("자동 상세조회: search_precedents -> get_precedent_text (상위 2건, full=false)"), text)
+  assert.ok(text.includes("상세 판례 111"), text)
+  assert.ok(text.includes("상세 판례 222"), text)
+  assert.ok(!text.includes("상세 판례 333"), text)
+}
+
+async function testIncludeTextPassesPrecedentOptionsToSearch() {
+  const { searchDecisions } = await import("../build/tools/unified-decisions.js")
+  const apiClient = makeApiClient()
+
+  await searchDecisions(apiClient, {
+    domain: "precedent",
+    query: "위약금 감액",
+    options: {
+      includeText: true,
+      court: "대법원",
+      fromDate: "20240101",
+      toDate: "20241231",
+      detailLimit: 1,
+    },
+    apiKey: "test",
+  })
+
+  assert.strictEqual(apiClient.searchRequests[0].extraParams.curt, "대법원")
+  assert.deepStrictEqual(apiClient.detailIds, ["111"])
+}
+
+async function main() {
+  await testDefaultPrecedentSearchRemainsListOnly()
+  await testIncludeTextFetchesBoundedPrecedentDetails()
+  await testIncludeTextPassesPrecedentOptionsToSearch()
+  console.log("search_decisions precedent includeText tests passed")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## 1. 개요

이 PR은 자연어 질의 기반 판례 검색에서 검색어가 과도하게 길거나 추상적인 경우 결과를 놓치는 문제를 줄이고, 검색 결과와 판례 본문조회의 연결을 안정화합니다.

주요 변경 방향은 판례 검색을 구조화된 공통 core로 모으고, 기존 텍스트 렌더링 형식은 유지하면서 체인 도구와 통합 검색에서 안정적으로 상세 증거를 붙일 수 있게 하는 것입니다.

## 2. 배경 및 문제

기존 판례 검색 경로는 호출 위치마다 동작이 조금씩 달랐습니다.

- 직접 `search_precedents` 호출은 목록 텍스트만 반환하고 상세조회는 별도 호출이 필요했습니다.
- 체인 도구는 렌더링된 텍스트에서 bracketed ID를 다시 추출해 상세조회를 이어갔습니다.
- 긴 자연어 질의나 개념형 질의는 법제처 판례 검색 API에 그대로 전달되면서 결과가 없다고 처리되는 경우가 있었습니다.
- 문서 검토, 종합 리서치, 불복 준비 등 여러 체인에서 판례 검색 fallback과 상세조회 연결 방식이 흩어져 있었습니다.
- 판례 검색 결과가 없을 때 LLM이 근거 없는 판례를 추측하지 않도록 실패 상태를 더 명확하게 전달할 필요가 있었습니다.

## 3. 주요 변경사항

### 3.1 구조화 판례 검색 core 추가

`src/tools/precedent-search-core.ts`를 추가했습니다.

- `searchPrecedentsStructured()`를 공통 판례 검색 진입점으로 도입했습니다.
- 검색 결과를 `hits`, `attempts`, `fallbackUsed`, `successfulAttempt`로 구조화했습니다.
- 사건번호가 있으면 사건번호 검색을 우선합니다.
- 제목 검색 실패 시 본문검색(`search=2`)을 시도합니다.
- compact query 후보를 이용해 긴 자연어 질의를 판례 API에 맞는 짧은 검색어로 보정합니다.
- 날짜 필터가 적용된 경우 실제 표시 hit 수와 `totalCount`가 어긋나지 않도록 처리했습니다.
- 날짜 조건으로 결과가 모두 걸러졌지만 raw hit가 있으면 `date_relaxed` fallback으로 요청 기간 밖 결과임을 표시할 수 있게 했습니다.

### 3.2 compact query 후보 생성 강화

`src/tools/compact-query-planner.ts`를 확장했습니다.

- 원 자연어 질의, 사건번호, 문서 검색 hint, query-router 후보, AI 법령검색 조문 신호를 후보로 사용합니다.
- 세금, 건설, 노동 등 도메인 축과 사실 축을 분리해 `법리축 + 사실축` 형태의 후보를 생성합니다.
- 후보별 출처, 점수, variant, 검증 필요 여부, 검증 term group을 보존합니다.
- 넓은 fallback 후보는 결과 검증을 거치도록 메타데이터를 제공합니다.

### 3.3 판례 상세 증거 연결 추가

`src/tools/precedent-evidence.ts`를 추가했습니다.

- `fetchPrecedentEvidence()`로 구조화 hit 상위 판례를 `get_precedent_text`에 연결합니다.
- 기본 상세조회 개수는 2건, 최대 5건으로 제한했습니다.
- 상세조회 일부 실패는 전체 실패로 숨기지 않고 실패 항목을 렌더링합니다.
- `validatePrecedentSearchResult()`로 fallback 결과가 원 질의 축과 맞는지 목록 및 필요 시 상세 본문으로 검증합니다.

### 3.4 기존 `search_precedents` 호환 유지

`src/tools/precedents.ts`를 구조화 core 기반으로 변경했습니다.

- 기존 `[id] 제목` 렌더링 형식을 유지했습니다.
- 결과 없음은 `[NOT_FOUND]`와 재시도 힌트를 포함해 명확히 반환합니다.
- fallback이 사용된 경우 어떤 검색어와 검색 범위로 성공했는지 출력합니다.
- 기존 `get_precedent_text` 상세조회 경로와 국세청 HTML fallback 경로는 유지했습니다.

### 3.5 체인 도구 판례 검색 경로 정리

`src/tools/chains.ts`의 판례 검색 연결을 공통 구조화 core로 정리했습니다.

- `chain_full_research`는 AI 법령검색 신호와 query-router 결과를 context로 넘겨 판례 검색 fallback 품질을 높입니다.
- `chain_dispute_prep`은 판례 목록과 상세 증거를 같은 구조화 검색 결과에서 이어 붙입니다.
- `chain_document_review`는 문서 분석 hint별로 구조화 판례 검색을 수행하고, 중복 hit를 합쳐 상위 상세 증거를 조회합니다.
- 체인 내부에서만 쓰던 취약한 재검색/상세조회 흐름을 공통 helper 중심으로 줄였습니다.

### 3.6 통합 결정례 검색에서 판례 본문 포함 옵션 지원

`src/tools/unified-decisions.ts`와 `src/tool-registry.ts`를 갱신했습니다.

- `search_decisions(domain="precedent", options.includeText=true)` 경로를 추가했습니다.
- `options.detailLimit`으로 자동 상세조회 개수를 지정할 수 있습니다.
- 기존 `search_decisions(domain="precedent")` 기본 동작은 유지합니다.

### 3.7 조문 기반 도구의 정확 검색 유지

`src/tools/article-with-precedents.ts`와 `src/tools/impact-map.ts`는 구조화 core를 사용하되 `fallbackPolicy: "none"`을 적용했습니다.

조문 기반 역방향 탐색은 검색어 의미가 넓어지면 오히려 부정확해질 수 있으므로, `${법령명} ${조문번호}` 기준의 정확 검색을 유지합니다.

### 3.8 개발 지침 문서 추가

`docs/PRECEDENT-SEARCH-GUIDELINES.md`를 추가했습니다.

- 판례 검색 관련 주요 호출 경로를 정리했습니다.
- 구조화 core, fallback 정책, 상세 증거 연결, 통합 검색 옵션을 문서화했습니다.
- 향후 판례 검색 수정 시 확인할 체크리스트와 권장 테스트를 포함했습니다.

## 4. 영향 범위

영향을 받는 주요 경로는 다음과 같습니다.

- `search_precedents`
- `get_precedent_text`
- `search_decisions(domain="precedent")`
- `search_decisions(domain="precedent", options.includeText=true)`
- `chain_full_research`
- `chain_dispute_prep`
- `chain_document_review`
- `get_article_with_precedents`
- `impact_map`

기존 MCP 노출 도구 목록은 유지하며, 새 exposed tool은 추가하지 않았습니다.

## 5. 호환성 고려

- 기존 `search_precedents`의 `[id] 제목` 형식은 유지했습니다.
- 기존 search-detail chain이 bracketed ID를 추출하는 흐름을 깨지 않도록 했습니다.
- `search_decisions`의 기본 판례 검색 동작은 유지하고, 본문 포함은 `options.includeText`로 opt-in 처리했습니다.
- 상세조회 자동 연결은 응답 크기와 외부 API 부하를 고려해 기본 2건, 최대 5건으로 제한했습니다.
- 조문 기반 영향도 검색은 자동 fallback을 끄고 정확 검색을 유지했습니다.

## 6. 검증

아래 명령을 실행해 확인했습니다.

```bash
npm run build
node test/test-precedent-search-core.cjs
node test/test-precedent-evidence.cjs
node test/test-chain-search-detail-integration.cjs
node test/test-chain-full-research-precedent-retry.cjs
node test/test-compact-query-planner.cjs
node test/test-precedent-search-scope.cjs
node test/test-search-decisions-precedent-include-text.cjs
node test/test-empty-html-retry.cjs
```

검증 결과:

- TypeScript build 통과
- 구조화 판례 검색 core 테스트 통과
- 판례 상세 증거 연결 테스트 통과
- 체인 검색-상세조회 통합 테스트 통과
- 종합 리서치 판례 fallback 테스트 통과
- compact query planner 테스트 통과
- 판례 검색 범위 테스트 통과
- `search_decisions` 판례 본문 포함 옵션 테스트 통과
- v4.0.8 빈/HTML 응답 retry 회귀 테스트 통과

## 7. 비고

전체 live 테스트는 외부 API 키와 네트워크 조건에 따라 달라질 수 있어 이번 검증 목록에는 포함하지 않았습니다. 판례 검색 관련 비-live 회귀 테스트와 빌드는 통과했습니다.