### PR TITLE
Add an example: exposing this MCP server as a Bindu agent over A2A (agno)

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -331,6 +331,10 @@ User: "산업안전보건법 별표1 내용"
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — System design
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) — Development guide
 
+## Related
+
+- [`examples/agno-bindu/`](examples/agno-bindu/) — a community-contributed example that wraps this MCP server as a network-addressable A2A agent with a DID identity using [Bindu](https://github.com/GetBindu/Bindu) (agno provides the agent loop). Additive only — it does not modify this repository's code.
+
 ## Credits
 
 - [법제처](https://www.law.go.kr) Open API — Korea's official legal database

--- a/README.md
+++ b/README.md
@@ -762,6 +762,10 @@ v4는 17개 도구만 노출합니다. 나머지 전문 도구는 `discover_tool
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — 시스템 설계
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) — 개발 가이드
 
+## 관련 예제 (Related)
+
+- [`examples/agno-bindu/`](examples/agno-bindu/) — 이 MCP 서버를 [Bindu](https://github.com/GetBindu/Bindu)로 감싸 DID 신원을 가진 네트워크 접근형 A2A 에이전트로 노출하는 커뮤니티 예제입니다(에이전트 루프는 agno). 본 저장소 코드는 수정하지 않는 추가 전용(additive) 예제입니다.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=chrisryugj%2Fkorean-law-mcp&type=timeline&legend=bottom-right">

--- a/examples/agno-bindu/.env.example
+++ b/examples/agno-bindu/.env.example
@@ -1,0 +1,22 @@
+# --- Korean-law MCP server (upstream) -------------------------------------
+# Required: a 법제처 국가법령정보 open-API key (the "OC"). The MCP server
+# cannot reach the law databases without it, so every answer would come
+# back empty. Issue a key (free) at https://open.law.go.kr/ and paste it here.
+LAW_OC=your-law-oc-key-here          # pragma: allowlist secret
+
+# Optional: protocol for the 법제처 API. Default https; use http only on a
+# closed network with certificate issues.
+# LAW_API_PROTOCOL=https
+
+# --- Language model (agno) ------------------------------------------------
+# Required: an OpenRouter key (https://openrouter.ai/keys). Drives the agent
+# loop that calls the MCP tools.
+OPENROUTER_API_KEY=sk-or-...          # pragma: allowlist secret
+
+# --- Optional Bindu / agent overrides -------------------------------------
+BINDU_AGENT_MODEL=anthropic/claude-sonnet-4.5
+BINDU_AGENT_NAME=bindu-lex-korea
+BINDU_AGENT_AUTHOR=your_email_here@example.com
+BINDU_AGENT_URL=http://localhost:3773
+# BINDU_AGENT_MAX_TOKENS=4096
+# BINDU_EXPOSE=true   # opens a PUBLIC, unauthenticated tunnel — read the README first

--- a/examples/agno-bindu/.gitignore
+++ b/examples/agno-bindu/.gitignore
@@ -1,0 +1,8 @@
+.env
+tmp/
+__pycache__/
+*.db
+
+# DID keypair generated at runtime — never commit the private key
+.bindu/
+*.pem

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -1,0 +1,487 @@
+# Exposing this MCP server as a network-addressable Bindu agent
+
+This directory contains a complete, working example of how to take the
+open-source **`korean-law-mcp`** Model Context Protocol server and expose
+it as a network-addressable A2A agent using
+[Bindu](https://github.com/GetBindu/Bindu).
+
+> **Community-built example.** Not affiliated with or endorsed by the
+> `korean-law-mcp` maintainer, 법제처 (the Korea Ministry of Government
+> Legislation), any Korean government body, or any law firm. The MCP server
+> is open source under its own LICENSE; this directory is example glue for
+> one possible way to drive it.
+
+It is contributed by the team at **Bindu**, where we are building a
+**compliance operating system for small and medium businesses**. The agent
+in this directory ("Lex Korea") is one of the reference agents we ship as
+part of that work, and the present pull request is the result of
+integrating the `korean-law-mcp` server into our compliance stack. We link
+back to this repository from Bindu's documentation as a technical
+reference — the canonical way to reach Korea's public legal corpora over
+MCP.
+
+## Maintenance
+
+The upstream MCP server (everything under `src/`, built to `build/`) is
+maintained by the `korean-law-mcp` author — please file issues there for
+anything to do with the tools or the underlying 법제처 data.
+
+For questions, bugs, or improvements specific to *this example* — the Bindu
+glue (`bindu_agent.py`, `cli.py`), the system prompt (`prompts.py`), or
+this README — please open an issue against
+[Bindu](https://github.com/GetBindu/Bindu) and tag the title with
+`[korean-law-mcp example]`, or reach the Bindu team on
+[Discord](https://discord.gg/3w5zuYUuwt). We will keep this directory in
+sync with the upstream server's tool surface.
+
+---
+
+## What the example does
+
+A program written against this example can ask Korean legal questions in
+plain Korean or English over a standard HTTP endpoint and receive answers
+that are grounded entirely in the tools this MCP server exposes — with
+citations to the underlying 법령, 판례, 해석례, 헌재 결정, and the
+specialist tribunal decisions. The agent is given a structured system
+prompt that requires it to call your tools rather than rely on the language
+model's training memory, and to cite each statement against the primary
+source it came from.
+
+The agent uses two open-source libraries:
+
+- **Bindu** — the framework we are building. It turns a Python function
+  into a network-addressable agent with its own cryptographic identity
+  (a Decentralized Identifier, or DID) and a public agent card, reachable
+  over the Agent-to-Agent JSON-RPC protocol defined at
+  https://github.com/google-a2a/A2A.
+- **agno** — used as the internal agent loop. It handles the
+  language-model API call, the tool-calling protocol, and short-term
+  conversation memory.
+
+The MCP server itself comes from this repository, unmodified. Because it is
+a Node/TypeScript server, it is built once (`npm run build`) and then
+launched as a child process; the agent communicates with it over standard
+input and output, as defined by the Model Context Protocol.
+
+---
+
+## How the pieces connect
+
+```
+┌─────────────────────────┐   HTTP request    ┌─────────────────────────────┐
+│ Any A2A-aware client    │ ────────────────▶ │  Bindu agent on :3773       │
+│ (curl, another agent,   │                   │  (agent card + DID)         │
+│  a frontend, …)         │                   └─────────────────────────────┘
+└─────────────────────────┘                                 │
+                                                            ▼
+                                              ┌─────────────────────────────┐
+                                              │  Language model             │
+                                              │  (via OpenRouter)           │
+                                              └─────────────────────────────┘
+                                                            │
+                                                  child process pipe (stdio)
+                                                            ▼
+                                              ┌─────────────────────────────┐
+                                              │  korean-law-mcp (this repo) │
+                                              │  build/index.js · MCP tools │
+                                              └─────────────────────────────┘
+                                                            │
+                                                            ▼
+                                          법제처 국가법령정보센터 open APIs
+                                              (law.go.kr · open.law.go.kr)
+```
+
+---
+
+## Setup
+
+The MCP server is the Node project in this repository; the agno + Bindu
+glue is a small, isolated Python environment that lives alongside it. The
+two are kept separate on purpose — your Node build is untouched.
+
+From the root of this repository, run:
+
+```bash
+# 1. Build the upstream Korean-law MCP server (Node ≥ 20.19).
+npm install
+npm run build            # tsc → build/index.js
+
+# 2. Create an isolated Python env for the agno + Bindu glue and install it.
+uv venv
+uv pip install -r examples/agno-bindu/requirements.txt
+
+# 3. Provide credentials.
+cp examples/agno-bindu/.env.example examples/agno-bindu/.env
+# Edit examples/agno-bindu/.env and set:
+#   LAW_OC             — your 법제처 open-API key (free): https://open.law.go.kr/
+#   OPENROUTER_API_KEY — your model key:                  https://openrouter.ai/keys
+```
+
+> **`LAW_OC` is required.** The MCP server reads its 법제처 (국가법령정보)
+> open-API key from `LAW_OC` in its own process environment. Without it,
+> every upstream API call returns empty and the agent has nothing to cite.
+> This example passes `LAW_OC` through to the launched server for you — you
+> only have to set it once in `.env`.
+
+The default model is `anthropic/claude-sonnet-4.5`, selected because it
+performs well on both tool use and Korean. You can switch the model by
+setting `BINDU_AGENT_MODEL` in `.env` to any identifier supported by
+OpenRouter — for example `openai/gpt-4o`, `google/gemini-2.5-pro`, or
+`deepseek/deepseek-chat`.
+
+---
+
+## Network exposure & dependencies
+
+This section flags three things that are easy to miss when running the
+example for the first time. Read it before you change the defaults.
+
+### Public network exposure is opt-in
+
+Bindu can open an [FRP](https://github.com/fatedier/frp) reverse tunnel
+that makes the agent's HTTP endpoint reachable on the public internet.
+That is useful for cross-network agent-to-agent calls, but it has two
+properties worth being explicit about:
+
+- The HTTP endpoint at `:3773` is **unauthenticated** at the transport
+  layer. Anyone who learns the FRP URL can hit `message/send`.
+- Each request runs through your configured LLM (OpenRouter or whichever
+  provider you set), so **your model-API key is on the billing path** for
+  any caller who reaches the agent. Your `LAW_OC` quota is likewise on the
+  path.
+
+Because of this, `bindu_agent.py` sets `expose` from a `BINDU_EXPOSE`
+env var and **defaults it to `false`**. Local development on
+`http://localhost:3773` works without changing anything. To enable the FRP
+tunnel, set `BINDU_EXPOSE=true` in `.env` deliberately, and review the rest
+of this section first.
+
+### `BINDU_AGENT_AUTHOR` ends up in the public DID
+
+Once the tunnel is on, the agent's DID — visible in every agent card fetch
+and embedded in every signed artifact — has the shape
+`did:bindu:<author>:<name>:<uuid>`, with `<author>` derived from whatever
+you set in `BINDU_AGENT_AUTHOR`. The example default in both `.env.example`
+and the agent card snippet below is the literal placeholder
+`your_email_here@example.com`, so you will notice immediately if you forgot
+to substitute your own value before turning on `BINDU_EXPOSE`.
+
+### Dependency breadth
+
+The `bindu` package on PyPI pulls a wider dependency tree than the example
+actually exercises, because Bindu integrates with several optional
+infrastructure layers and ships their clients in the core distribution. As
+of this PR, that includes (non-exhaustive): [OpenTelemetry](https://opentelemetry.io/)
+traces, [Sentry](https://sentry.io/) error reporting (off unless a DSN is
+set), an [Ory Hydra](https://www.ory.sh/hydra/) OAuth2 client (off unless
+Hydra URLs are set), and an [x402](https://x402.io/) / USDC micropayment
+client (off unless a wallet is configured). Each is **opt-in** via
+environment variables — none is engaged in this example — but the libraries
+are installed into the Python env regardless. If you prefer a narrower
+footprint, run the example against `cli.py`, which exercises the agno + MCP
+path without Bindu in the loop.
+
+---
+
+## Running the agent
+
+The primary entry point is the Bindu A2A service:
+
+```bash
+uv run python examples/agno-bindu/bindu_agent.py
+```
+
+This starts a network-addressable agent on port 3773. The MCP server is
+started once when the program loads and is kept running across all
+subsequent requests, which avoids the cost of restarting the Node process
+for every question. The endpoints the service exposes are documented in the
+API reference below.
+
+For quick local checks without spinning up the network service, you can
+also use the command-line script. It opens the MCP server, asks one
+question, prints the cited answer, and exits:
+
+```bash
+uv run python examples/agno-bindu/cli.py "민법 제750조의 현행 조문은?"
+uv run python examples/agno-bindu/cli.py "음주운전 처벌 기준을 법령과 별표로 알려줘"
+uv run python examples/agno-bindu/cli.py \
+  "전세 사기 관련 대법원 판례를 찾아서 사건번호와 한 줄 요지만 알려줘"
+```
+
+---
+
+## API reference
+
+The Bindu A2A service exposes the endpoints below at
+`http://localhost:3773` by default. The shapes shown here apply to any A2A
+deployment of this example.
+
+### `GET /.well-known/agent.json`
+
+Returns the agent's public agent card. The card describes who the agent is,
+what it can do, and how to talk to it. Any A2A-aware client should fetch
+this first.
+
+```bash
+curl -s http://localhost:3773/.well-known/agent.json | jq
+```
+
+**Example response (abridged):**
+
+```json
+{
+  "name": "bindu-lex-korea",
+  "description": "An agentic Korean legal research assistant…",
+  "url": "http://localhost:3773",
+  "protocolVersion": "1.0.0",
+  "kind": "agent",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "extensions": [
+      {
+        "uri": "did:bindu:your_email_here_at_example_com:bindu-lex-korea:<uuid>",
+        "description": "DID-based identity for bindu-lex-korea",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"]
+}
+```
+
+The `capabilities.extensions[].uri` field contains the agent's
+Decentralized Identifier (DID), which uniquely identifies this agent
+instance.
+
+### `GET /health`
+
+Returns a small JSON health-check payload. Useful for liveness probes; look
+for `health: healthy`, `runtime.task_manager_running: true`, and
+`application.agent_did`.
+
+```bash
+curl -s http://localhost:3773/health | jq
+```
+
+### `POST /` (JSON-RPC 2.0)
+
+This is the main endpoint. It accepts JSON-RPC 2.0 requests. The two
+methods this example supports are `message/send` and `tasks/get`.
+
+#### Method: `message/send`
+
+Submits a new question. The agent runs asynchronously, so this method does
+**not** return the final answer directly — it returns a task whose
+`status.state` is `submitted`. The client then polls `tasks/get` until the
+task reaches a terminal state.
+
+All four identifier fields — the JSON-RPC `id`, `message.messageId`,
+`message.contextId`, and `message.taskId` — **must be valid UUIDs** (a
+plain `"1"` is rejected with a 400). Reuse `contextId` across turns of the
+same conversation; use a fresh `taskId` per question.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<a UUID for this RPC call>",
+  "method": "message/send",
+  "params": {
+    "configuration": { "acceptedOutputModes": ["text/plain"] },
+    "message": {
+      "role": "user",
+      "messageId": "<a UUID>",
+      "contextId": "<a UUID identifying the conversation>",
+      "taskId":    "<a UUID identifying the task>",
+      "kind": "message",
+      "parts": [
+        { "kind": "text", "text": "민법 제750조의 현행 조문은?" }
+      ]
+    }
+  }
+}
+```
+
+#### Method: `tasks/get`
+
+Fetches the current state of a previously submitted task. Note the params
+take `{"taskId": "…"}` (the `taskId` from `message/send`), not `{"id": …}`.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<a fresh UUID for this RPC call>",
+  "method": "tasks/get",
+  "params": { "taskId": "<the taskId from message/send>" }
+}
+```
+
+When finished, the answer text is at
+`result.artifacts[0].parts[0].text`. The `status.state` field moves through:
+
+| State            | Meaning                                                   |
+|------------------|-----------------------------------------------------------|
+| `submitted`      | The request was accepted; processing has not started yet. |
+| `working`        | The agent is processing the request.                      |
+| `input-required` | The agent needs clarification before it can continue.     |
+| `completed`      | The agent has finished; the answer is in `artifacts`.     |
+| `failed`         | The agent could not complete the request.                 |
+
+### Try it out
+
+The shell snippet below sends one question and prints the final answer. It
+generates the four required UUIDs, submits `message/send`, then polls
+`tasks/get` until the task is terminal.
+
+```bash
+uuid() { uuidgen | tr 'A-Z' 'a-z'; }
+RPC_ID=$(uuid); MSG_ID=$(uuid); CTX_ID=$(uuid); TASK_ID=$(uuid)
+
+# Submit the question.
+curl -s -X POST http://localhost:3773 \
+  -H 'content-type: application/json' \
+  -d "{
+    \"jsonrpc\":\"2.0\",\"id\":\"$RPC_ID\",\"method\":\"message/send\",
+    \"params\":{
+      \"configuration\":{\"acceptedOutputModes\":[\"text/plain\"]},
+      \"message\":{
+        \"role\":\"user\",\"messageId\":\"$MSG_ID\",
+        \"contextId\":\"$CTX_ID\",\"taskId\":\"$TASK_ID\",
+        \"kind\":\"message\",
+        \"parts\":[{\"kind\":\"text\",\"text\":\"민법 제750조의 현행 조문은? 한 줄로.\"}]
+      }
+    }
+  }" > /dev/null
+
+# Poll until the task is finished.
+while true; do
+  RESP=$(curl -s -X POST http://localhost:3773 \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":\"$(uuid)\",\"method\":\"tasks/get\",
+         \"params\":{\"taskId\":\"$TASK_ID\"}}")
+  STATE=$(echo "$RESP" | jq -r '.result.status.state // "?"')
+  echo "state: $STATE"
+  case "$STATE" in
+    completed|failed|input-required)
+      echo "$RESP" | jq -r '.result.artifacts[0].parts[0].text'
+      break ;;
+  esac
+  sleep 2
+done
+```
+
+> **A note on file uploads.** Send questions as `text` parts, as shown. If
+> you want the agent to review a contract or 약관, paste the **text** of the
+> document into the message (the agent's `analyze_document` /
+> `chain_document_review` tools take text). Binary file parts are not part
+> of this example's supported surface.
+
+---
+
+## The MCP tools
+
+The agent has access to the full read-mostly tool surface this server
+exposes over the 법제처 국가법령정보 APIs — statute search and retrieval
+(`search_law`, `get_law_text`, `get_article_detail`), administrative rules
+and local ordinances, court precedents and interpretations
+(`search_precedents`, `search_interpretations`), the specialist tribunals
+(헌재 · 행정심판 · 조세심판 · 관세 · 공정위 · 개인정보위 · 노동위 · 권익위 ·
+소청심사, reachable directly or via the unified `search_decisions`), and the
+headline analysis tools `verify_citations` (citation hallucination guard),
+`impact_map` (article impact graph), and `analyze_document`. Multi-database
+`chain_*` orchestrators and the `discover_tools` / `execute_tool` meta-layer
+cover complex and long-tail questions. The agent selects among them
+automatically based on the question; the authoritative reference for each
+tool is this repository's top-level `README.md` / `README-EN.md`.
+
+---
+
+## How the agent is instructed
+
+The system prompt (`prompts.py`) is the part of the example that turns a
+general-purpose language model into a Korean legal research assistant. It is
+broken into labelled sections so each rule the agent must follow is
+unambiguous, and it pins the agent to four behaviours:
+
+1. **Every answer must come from this MCP server.** The agent is instructed
+   never to answer from training memory when the question touches a Korean
+   statute, precedent, interpretation, or tribunal decision.
+2. **The agent must cite every claim** — statutes by 법령명 and 조문, cases
+   by 사건번호 / 판례일련번호, decisions by their issuing body and number.
+3. **The agent prefers the cheapest precise call.** It resolves a 법령명 via
+   `search_law` and then fetches the article, rather than keyword-sweeping;
+   it reserves the `chain_*` orchestrators for genuinely multi-database
+   questions.
+4. **The agent declines questions outside Korean jurisdiction** and asks one
+   targeted clarifying question when the request is genuinely ambiguous,
+   instead of guessing.
+
+---
+
+## End-to-end verification
+
+The following queries were executed against the **live 법제처 국가법령정보
+API** (via the local `korean-law-mcp` server) during integration testing of
+this example — each one run **both** through `cli.py` and through the live
+A2A service (`message/send` → poll `tasks/get` → `completed`). The model was
+`anthropic/claude-sonnet-4.5` via OpenRouter.
+
+| # | Capability (tool) | Question | Path | Outcome |
+|---|---|---|---|---|
+| 1 | Statute retrieval (`search_law`→`get_law_text`) | 민법 제750조의 현행 조문 전문 | CLI + A2A | Returned 제750조(불법행위의 내용) verbatim, `MST 284415`, 시행 2026-03-17, with a Sources citation. |
+| 2 | 별표/서식 (`get_annexes`) | 산업안전보건법 시행규칙 [별표 1]의 제목·근거조문 | CLI + A2A | Returned the title (건설업체 산업재해발생률 산정 기준…) and 근거 조문 (제4조 관련). |
+| 3 | Case law (`search_decisions` domain=precedent) | 전세 사기 관련 대법원 판례 한 건 + 사건번호·요지 | CLI + A2A | Returned 대법원 2025. 5. 29. 선고 `2023다244871` 판결 (판례일련번호 `613097`) with a one-line holding. |
+| 4 | Citation hallucination guard (`verify_citations`) | 민법 제750조 / 제9999조 인용이 실존하는지 검증 | CLI + A2A | Verified 제750조 as real; flagged 제9999조 as non-existent (민법 ends at 제1118조). On A2A the tool hit a transient network blip and the agent fell back to a direct `get_law_text` check, reaching the same correct verdict. |
+| 5 | Article impact graph (`impact_map`) | 민법 제103조를 인용한 판례·해석례 영향 맵 | CLI + A2A | Returned 9 citing sources (대법원 판례 1, 헌재 결정 6, 자치법규 2) with a mermaid diagram. |
+| 6 | Out-of-scope (no tool call) | "Most recent U.S. Supreme Court ruling on affirmative action?" | CLI + A2A | Declined politely with **no tool call**, scoped itself to Korean law, pointed to Justia / SCOTUSblog / Oyez. |
+| 7 | Ambiguous (no tool call) | "그 법 언제 개정됐어?" | CLI + A2A | Asked **one** clarifying question (which 법령?) in Korean and stopped — **no tool call**. |
+
+Tests 6 and 7 demonstrate that the prompt's scope and ambiguity rules take
+effect without any tool call, which is the desired behaviour.
+
+Alongside the table, the following were confirmed:
+
+- `GET /.well-known/agent.json` returns the agent's DID under
+  `capabilities.extensions[].uri`
+  (`did:bindu:…:bindu-lex-korea:…`).
+- `GET /health` reports `health: healthy` and
+  `runtime.task_manager_running: true`.
+- A **single** `korean-law-mcp` Node subprocess (one `build/index.js`
+  process) served **all** seven A2A calls — the background event loop keeps
+  it warm rather than respawning it per request.
+
+---
+
+## Files in this directory
+
+```
+examples/agno-bindu/
+├── README.md           This document.
+├── prompts.py          The system prompt and the agent's description.
+├── agent.py            The agent definition (model, instructions, MCP launch, memory).
+├── cli.py              The one-shot command-line runner.
+├── bindu_agent.py      Exposes the agent over the A2A protocol via Bindu.
+├── requirements.txt    The Python packages the glue needs (agno + Bindu side).
+├── .env.example        Required environment variables.
+└── .gitignore          Local artefacts that should not be committed.
+```
+
+---
+
+## A note on scope and dependencies
+
+This example does not modify any code under `src/`, does not change your CI
+configuration, and does not add any new dependencies to your `package.json`.
+All extra packages live in `examples/agno-bindu/requirements.txt` (a
+separate Python environment) and are strictly opt-in.
+
+The intent is to make it easy for downstream users to extend your MCP server
+into a fully autonomous, network-addressable agent without forking your
+repository. If at any point you would prefer a different structure — for
+example moving the example to its own repository under the Bindu org, or
+different README pointers — the Bindu team is happy to accommodate.
+
+Thank you for open-sourcing this server. The breadth of the 법제처 coverage
+here — 법령, 자치법규, 판례, and the full set of specialist tribunals behind
+one MCP surface — is what makes an agent like this possible.

--- a/examples/agno-bindu/agent.py
+++ b/examples/agno-bindu/agent.py
@@ -1,0 +1,125 @@
+"""Lex Korea — the agent definition.
+
+This module defines the agent and how it should be launched. It does not
+start any server by itself. The agent is consumed in two ways:
+
+- `cli.py` imports it for one-shot command-line questions.
+- `bindu_agent.py` imports it and exposes it over the A2A protocol as a
+  Bindu microservice. This is the primary entry point for the example.
+
+The Model Context Protocol (MCP) server lives in this repository — it is the
+Node/TypeScript `korean-law-mcp` server. We launch its built entry point
+(`build/index.js`) as a child process over stdio, so no global npm install of
+`korean-law-mcp` is required; a local `npm install && npm run build` at the
+repo root is enough.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent.resolve()
+REPO_ROOT = HERE.parent.parent.resolve()  # examples/agno-bindu → repo root
+
+# Load this example's .env deterministically, regardless of the current
+# working directory (so `cli.py` run from the repo root still picks it up).
+load_dotenv(HERE / ".env")
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openrouter import OpenRouter
+from mcp import StdioServerParameters
+from mcp.client.stdio import get_default_environment
+
+from prompts import AGENT_DESCRIPTION, AGENT_NAME, SYSTEM_PROMPT
+
+DB_PATH = HERE / "tmp" / "lex_korea.db"
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+# The built Node entry point. `npm run build` (tsc) emits this from src/index.ts.
+MCP_ENTRY = REPO_ROOT / "build" / "index.js"
+
+
+def _mcp_server_params() -> StdioServerParameters:
+    """Build the launch command for the local Korean-law MCP server.
+
+    Runs the repo's built Node entry point in its default stdio mode. The
+    upstream server reads its 법제처 open-API key from `LAW_OC` in its own
+    process environment — and the MCP stdio client does NOT inherit arbitrary
+    parent env vars, only a small safe set (PATH, HOME, …). So we merge
+    `LAW_OC` (and the optional `LAW_API_PROTOCOL`) into the child env
+    explicitly; otherwise every upstream API call comes back unauthenticated.
+    """
+    if not MCP_ENTRY.exists():
+        raise RuntimeError(
+            f"Korean-law MCP server is not built: {MCP_ENTRY} is missing. "
+            "Run `npm install && npm run build` at the repo root first "
+            "(see examples/agno-bindu/README.md → Setup)."
+        )
+
+    law_oc = os.getenv("LAW_OC") or os.getenv("KOREAN_LAW_API_KEY")
+    if not law_oc:
+        raise RuntimeError(
+            "LAW_OC is not set. The korean-law-mcp server needs a 법제처 "
+            "(국가법령정보) open-API key to answer. Issue one at "
+            "https://open.law.go.kr/ and add LAW_OC to your .env "
+            "(see .env.example)."
+        )
+
+    child_env = {
+        **get_default_environment(),
+        "LAW_OC": law_oc,
+        "LAW_API_PROTOCOL": os.getenv("LAW_API_PROTOCOL", "https"),
+    }
+    return StdioServerParameters(
+        command="node",
+        args=[str(MCP_ENTRY)],
+        cwd=str(REPO_ROOT),
+        env=child_env,
+    )
+
+
+def _build_model():
+    """Select the language model used by the agent.
+
+    OpenRouter is used as a single endpoint that gives access to many
+    providers. The default is `anthropic/claude-sonnet-4.5`, which we have
+    found to perform well on both tool use and Korean. The model can be
+    changed by setting the `BINDU_AGENT_MODEL` environment variable to any
+    model identifier supported by OpenRouter.
+    """
+    model_id = os.getenv("BINDU_AGENT_MODEL", "anthropic/claude-sonnet-4.5")
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "OPENROUTER_API_KEY is not set. Add it to your .env file "
+            "(see .env.example for the expected layout)."
+        )
+    return OpenRouter(
+        id=model_id,
+        api_key=api_key,
+        max_tokens=int(os.getenv("BINDU_AGENT_MAX_TOKENS", "4096")),
+    )
+
+
+def build_agent() -> Agent:
+    """Create the agent. Tools are attached when the MCP connection opens."""
+    return Agent(
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+        instructions=SYSTEM_PROMPT,
+        model=_build_model(),
+        db=SqliteDb(db_file=str(DB_PATH)),
+        add_history_to_context=True,
+        num_history_runs=3,
+        add_datetime_to_context=True,
+        markdown=True,
+    )
+
+
+# Module-level instance so `cli.py` and `bindu_agent.py` can import it.
+agent: Agent = build_agent()

--- a/examples/agno-bindu/bindu_agent.py
+++ b/examples/agno-bindu/bindu_agent.py
@@ -1,0 +1,139 @@
+"""Lex Korea exposed as a Bindu A2A agent.
+
+Bridges agno's async MCP toolkit to Bindu's sync handler contract:
+
+- A background asyncio event loop runs in a daemon thread.
+- The MCP stdio connection is opened ONCE on that loop at module load,
+  so the Korean-law MCP server (Node) starts a single time and stays warm
+  across every A2A `message/send` request.
+- The sync handler that Bindu invokes hops onto the background loop
+  with `run_coroutine_threadsafe(...)` and waits for the result.
+
+Run with:
+    uv run python examples/agno-bindu/bindu_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import os
+import threading
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent.resolve()
+load_dotenv(HERE / ".env")
+
+from agno.tools.mcp import MCPTools
+
+from agent import _mcp_server_params, agent
+from prompts import AGENT_DESCRIPTION
+
+from bindu.penguin.bindufy import bindufy
+
+
+# --- Background event loop ---------------------------------------------------
+# Bindu's handler contract is sync, but agno + MCPTools are async-only.
+# We run a dedicated asyncio loop in a daemon thread and marshal each
+# handler call onto it. This also lets us keep ONE MCP connection alive
+# across requests instead of fork-restarting the stdio server every time.
+
+_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+_mcp_tools: MCPTools | None = None
+_ready = threading.Event()
+
+
+def _run_loop() -> None:
+    asyncio.set_event_loop(_loop)
+    _loop.run_forever()
+
+
+_loop_thread = threading.Thread(target=_run_loop, name="lex-korea-loop", daemon=True)
+_loop_thread.start()
+
+
+async def _open_mcp() -> None:
+    global _mcp_tools
+    _mcp_tools = MCPTools(server_params=_mcp_server_params())
+    await _mcp_tools.connect()
+    agent.tools = [_mcp_tools]
+
+
+async def _close_mcp() -> None:
+    if _mcp_tools is not None:
+        await _mcp_tools.close()
+
+
+asyncio.run_coroutine_threadsafe(_open_mcp(), _loop).result()
+_ready.set()
+
+
+def _shutdown() -> None:
+    if not _loop.is_running():
+        return
+    try:
+        asyncio.run_coroutine_threadsafe(_close_mcp(), _loop).result(timeout=5)
+    except Exception:
+        pass
+    _loop.call_soon_threadsafe(_loop.stop)
+
+
+atexit.register(_shutdown)
+
+
+# --- Bindu handler -----------------------------------------------------------
+
+
+async def _arun(content: str) -> str:
+    result = await agent.arun(content)
+    return result.content if hasattr(result, "content") else str(result)
+
+
+def handler(messages: list[dict[str, str]]):
+    """Sync Bindu handler. Hops the prompt onto the background loop."""
+    if not messages:
+        return (
+            "Ask a Korean legal question — 법령 (statutes), 판례 (court "
+            "precedents), 행정규칙·자치법규, 해석례, or 헌재 결정. I ground "
+            "every answer in the 법제처 국가법령정보 databases and cite the "
+            "primary source."
+        )
+
+    last = messages[-1]
+    content = last.get("content", "") if isinstance(last, dict) else str(last)
+    if not content.strip():
+        return "Empty message — please send a question."
+
+    _ready.wait(timeout=30)
+    future = asyncio.run_coroutine_threadsafe(_arun(content), _loop)
+    return future.result()
+
+
+# --- Bindu config ------------------------------------------------------------
+
+config = {
+    # `BINDU_AGENT_AUTHOR` ends up inside the public agent card DID once
+    # `expose` is on, so the default is a clearly-fake placeholder rather
+    # than something that looks like a real address. Override in .env.
+    "author": os.getenv("BINDU_AGENT_AUTHOR", "your_email_here@example.com"),
+    "name": os.getenv("BINDU_AGENT_NAME", "bindu-lex-korea"),
+    "description": AGENT_DESCRIPTION,
+    "deployment": {
+        "url": os.getenv("BINDU_AGENT_URL", "http://localhost:3773"),
+        # Opt-in only. Setting BINDU_EXPOSE=true asks Bindu to open an
+        # FRP reverse tunnel that makes this agent's HTTP endpoint
+        # reachable on the public internet. The endpoint is unauthenticated
+        # and any model-API key configured here is on the billing path.
+        # Leave this off unless you have read the README's
+        # "Network exposure & dependencies" section.
+        "expose": os.getenv("BINDU_EXPOSE", "false").lower() == "true",
+        "cors_origins": ["http://localhost:5173"],
+    },
+    "capabilities": {"streaming": False},
+}
+
+
+if __name__ == "__main__":
+    bindufy(config, handler)

--- a/examples/agno-bindu/cli.py
+++ b/examples/agno-bindu/cli.py
@@ -1,0 +1,68 @@
+"""One-shot command-line runner for the Lex Korea agent.
+
+Usage:
+    uv run python examples/agno-bindu/cli.py "민법 제750조 현행 조문"
+    uv run python examples/agno-bindu/cli.py "음주운전 처벌 기준 알려줘"
+
+Opens the local Korean-law MCP server, runs the agent against a single
+question, renders the cited answer to the terminal as formatted Markdown,
+and exits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from agno.tools.mcp import MCPTools
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.rule import Rule
+
+from agent import _mcp_server_params, agent
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+async def ask(question: str) -> str:
+    async with MCPTools(server_params=_mcp_server_params()) as mcp_tools:
+        agent.tools = [mcp_tools]
+        result = await agent.arun(question)
+        return result.content if hasattr(result, "content") else str(result)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        err_console.print(
+            "[bold red]Error:[/bold red] please pass a question as an argument.\n"
+            "[dim]example:[/dim] uv run python examples/agno-bindu/cli.py "
+            '"민법 제750조의 현행 조문은?"'
+        )
+        return 2
+
+    question = " ".join(sys.argv[1:])
+
+    console.print(Panel.fit(question, title="Question", border_style="cyan"))
+    console.print()
+
+    try:
+        with err_console.status(
+            "[bold cyan]Lex Korea is researching…[/bold cyan]", spinner="dots"
+        ):
+            answer = asyncio.run(ask(question))
+    except KeyboardInterrupt:
+        err_console.print("[yellow]Cancelled.[/yellow]")
+        return 130
+    except Exception as exc:
+        err_console.print(f"[bold red]Error:[/bold red] {exc}")
+        return 1
+
+    console.print(Rule(style="dim"))
+    console.print(Markdown(answer))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agno-bindu/prompts.py
+++ b/examples/agno-bindu/prompts.py
@@ -1,0 +1,137 @@
+"""System prompt for the Korean Legal Research Agent.
+
+The prompt is broken into labelled sections so each rule the agent must
+follow is unambiguous: who is on the other end, when to call tools and when
+not to, how to research a Korean legal question, how to cite sources, the
+tool inventory itself, and what to do when the question is ambiguous or
+out-of-scope.
+"""
+
+from textwrap import dedent
+
+# Display name kept as "Lex Korea" for the operator-facing prose. The
+# Bindu agent card identifier (set in bindu_agent.py) is the
+# vendor-prefixed `bindu-lex-korea` so the DID stays clearly namespaced.
+AGENT_NAME = "Lex Korea"
+AGENT_DESCRIPTION = (
+    "An agentic Korean legal research assistant: statutes (법령), administrative "
+    "rules (행정규칙), local ordinances (자치법규), court precedents (판례), "
+    "constitutional decisions (헌재), and the specialist tribunals — sourced live "
+    "from the Korea Ministry of Government Legislation's 국가법령정보센터 "
+    "(법제처) open APIs. Verifies citations against the primary source to guard "
+    "against hallucination. Community-built example. Not affiliated with or "
+    "endorsed by the korean-law-mcp maintainer, 법제처, or any law firm."
+)
+
+
+SYSTEM_PROMPT = dedent(
+    """\
+    You are Lex Korea, an agentic AI legal-research assistant for Korean (대한민국) law. You are a community-built example, not affiliated with or endorsed by 법제처 (the Korea Ministry of Government Legislation), any Korean government body, the korean-law-mcp maintainer, or any law firm.
+    You operate on an MCP-first paradigm: every substantive answer must be grounded in a tool call against the 국가법령정보센터 (법제처) open APIs, never your training memory. Korean statutes are amended frequently, so a cited current article always beats a remembered one.
+    You pair-research with a USER — a researcher, paralegal, law student, public official, or informed citizen, possibly a lawyer doing background research — to answer questions about 법령, 행정규칙, 자치법규, 판례, 해석례, 헌재 결정, and the specialist administrative tribunals.
+    The USER will send you legal questions. Prioritize their literal request first; supporting analysis comes after the cited primary source.
+
+    <user_information>
+    The USER is interacting with you via a JSON-RPC / A2A endpoint. You do not see their OS, editor, or files.
+    The USER may write in Korean, English, or a mix. Mirror their language in your final answer.
+    Internal reasoning (tool selection, query construction) may be in English regardless of the USER's language.
+    </user_information>
+
+    <tool_calling>
+    You have a large MCP tool surface that talks to the 법제처 국가법령정보 databases. Follow these rules strictly:
+    1. IMPORTANT: Only call tools when they are necessary to ground the answer in a primary source. If the USER asks a general procedural or definitional question ("판례와 결정례 차이가 뭐야?", "법령 약칭이 뭐야?"), answer without a tool call.
+    2. IMPORTANT: If you state that you will look something up, immediately issue the tool call as your next action. Do not narrate the lookup and then stop.
+    3. Always follow each tool's parameter schema exactly. Never invent fields.
+    4. Never call a tool that is not in your loaded tool list. The MCP surface is fixed; if a capability you want is not there, use `discover_tools` to find a specialist tool, then `execute_tool` to run it.
+    5. Before each tool call, write ONE short sentence explaining why you are calling it (which database, what you expect back).
+    6. Chain tools in the obvious order: search → get. Never call `get_law_text` without a real `mst`/`lawId` (from `search_law` first), and never call `get_decision_text` without an `id` (from `search_decisions` first).
+    7. Prefer the cheapest precise call. A known 법령명 resolved via `search_law` → `get_law_text(jo=...)` beats a chain. Reserve the `chain_*` orchestrators for questions that genuinely span multiple databases (full structure, dispute prep, amendment history, procedure). For specialist tribunals use `search_decisions(domain=...)`; only drop to `discover_tools` → `execute_tool` for capabilities none of the other tools cover (e.g. 행정규칙·자치법규 직접 조회, 조항호목 단위 정밀조회, 용어사전).
+    8. Batch independent lookups in parallel when they do not depend on each other (e.g. two unrelated articles the USER asked about together).
+    9. If a tool returns an error or empty result, inspect the message before retrying. Common fixes: relax the keyword, use `suggest_law_names` to resolve an exact 법령명, switch to `search_ai_law` for natural-language semantic search, or use `search_all` when the domain (법령 vs 행정규칙 vs 자치법규) is unclear.
+    10. NEVER fabricate an `mst`, `lawId`, 판례일련번호, 헌재 사건번호, or a citation. If you cannot find it via the tools, say so explicitly. When the USER hands you citations, you may run `verify_citations` to confirm they exist before relying on them.
+    </tool_calling>
+
+    <legal_research_method>
+    Default research order for substantive questions:
+    1. Identify the legal domain (민사 / 형사 / 행정 / 헌법 / 조세 / 노동 / 자치법규 …) and whether the USER needs the statute text, case law, an interpretation, or a tribunal decision.
+    2. Pull the controlling statute first: `search_law` to resolve the 법령명 → `mst`/`lawId`, then `get_law_text(jo=...)` for the precise article. This anchors reasoning to the text currently in force. Amounts and thresholds usually live in 별표 — use `get_annexes`.
+    3. Pull case law and tribunal decisions through `search_decisions(domain=...)` (`domain="precedent"` for 대법원 판례, `"constitutional"` for 헌재, `"admin_appeal"` for 행정심판, `"interpretation"` for 법령해석례, etc.), then `get_decision_text(domain, id)` for the holding. Set `options.includeText=true` when you need the body inline.
+    4. For multi-step or vague questions, prefer a chain over hand-orchestrating: `chain_full_research` (법령명 불명확), `chain_dispute_prep` (불복·소송 준비), `chain_action_basis` (처분 근거), `chain_amendment_track` (개정 이력), `chain_law_system` / `chain_ordinance_compare` (체계), `chain_procedure_detail` (절차·서식·수수료). A chain runs several lookups in parallel and returns a synthesized result.
+    5. Cross-check currency and flag any later 개정. When you (or the USER) have written citations, run `verify_citations` to confirm each 조문 actually exists before relying on it. For capabilities the 15 tools above do not cover (행정규칙·자치법규 직접 조회, 조항호목 단위 정밀조회, 통계, 이력, 용어사전), use `discover_tools(intent=...)` → `execute_tool`.
+
+    Quality bar:
+    - Every legal proposition must be attributable to a specific tool result (an `mst` + 조문, a 판례일련번호, a 헌재 사건번호, a 해석례 번호). If you cannot attribute it, drop it or label it as 일반 학리.
+    - Amounts, thresholds, and 과태료/과징금 schedules frequently live in 별표/별지 — use `get_annexes` rather than guessing.
+    - Quote sparingly but exactly. Translate Korean only when the USER's question is in English, and keep the original Korean term in parentheses on first mention.
+    - Note when a 법령 has been 개정 or a 판례 has been superseded by a later one.
+    </legal_research_method>
+
+    <citation_format>
+    When you cite primary sources, use this format (mirror the USER's language for the surrounding prose):
+
+    - Statute article: `《<법령명>》 제<조>조<제N항?><제N호?>` — e.g. `《민법》 제750조`, `《도로교통법》 제44조 제1항`. Note the 시행일 when relevant.
+    - Court precedent: `<법원> <선고일> 선고 <사건번호> 판결` — e.g. `대법원 2022. 5. 12. 선고 2021다12345 판결`. Include the 판례일련번호 where the tool returned one.
+    - Constitutional decision: `헌법재판소 <선고일> <사건번호> 결정` — e.g. `헌재 2015. 2. 26. 2009헌바17 결정`.
+    - Interpretation / tribunal decision: name the issuing body and the 안건/결정 번호 (e.g. 법제처 해석례, 조세심판원 결정).
+
+    Always end the answer with a `### 출처 (Sources)` section listing every tool-call-derived source as a bulleted list with: citation, one-line relevance, and a permalink if the tool returned one.
+    </citation_format>
+
+    <available_tools>
+    The MCP server `korean-law` exposes exactly 17 tools, and these are the ONLY tools you may call. Many specialist databases (판례 본문, 행정규칙, 자치법규, 조항호목 단위, 통계, 이력, 용어사전 …) are NOT separate top-level tools — they are reached through `search_decisions`/`get_decision_text` or through the `discover_tools`/`execute_tool` meta-layer. The full schema for each tool is loaded into your tool list at runtime; this is the operator's cheat sheet.
+
+    법령 (Statutes) — direct:
+    - `search_law(query, display?)` — keyword-search a 법령명 → `lawId`, `mst`. Auto-resolves 약칭. The usual first step.
+    - `get_law_text(mst|lawId, jo?)` — full article text; pass `jo` for one article (the natural form `"제750조"` works; the server normalizes it to the 6-digit JO code). Requires an `mst`/`lawId` from `search_law`.
+    - `get_annexes(lawName, ...)` — 별표/서식. Amounts, 기준, 과태료/과징금 schedules usually live here.
+
+    Decisions & tribunals — many domains behind one pair:
+    - `search_decisions(domain, query?, options?)` — search one domain. `domain` ∈ precedent(대법원 판례) · interpretation(법령해석례) · constitutional(헌재) · admin_appeal(행정심판) · tax_tribunal(조세심판) · customs(관세) · nts(국세청 해석) · ftc(공정위) · pipc(개인정보위) · nlrc(노동위) · acr(권익위) · appeal_review(소청심사) · treaty(조약) · english_law(영문법령) · school/public_corp/public_institution(규정). Set `options.includeText=true` to inline 판례 본문.
+    - `get_decision_text(domain, id, full?)` — full text of one decision; `id` comes from `search_decisions`.
+
+    Headline analysis:
+    - `verify_citations(text, maxCitations?)` — extract statute citations from any text and check each one actually exists in the 법제처 DB. The hallucination guard — use it on a draft answer, a contract, or the USER's own citations.
+    - `impact_map(lawName, jo, includeOrdinances?, includeMermaid?)` — reverse-graph of every 판례·헌재·해석례·행심·자치법규 that cites one article, plus the laws it cites, with a mermaid diagram. `lawName` + `jo` required.
+
+    Chain orchestrators (⛓ multi-database; each takes a natural-language `query`, runs several lookups in parallel, returns a synthesis):
+    - `chain_law_system(query)` — one law's full structure (3단 + 위임조문 + 하위법령 + 별표).
+    - `chain_action_basis(query)` — legal basis of an administrative disposition/permit (3단 + 해석례 + 판례 + 행심).
+    - `chain_dispute_prep(query)` — appeal/litigation prep (판례 + 행정심판 + the domain's 결정례).
+    - `chain_amendment_track(query)` — amendment history (신구대조 + 조문 이력 + 연혁법령).
+    - `chain_ordinance_compare(query)` — ordinance analysis (상위법령 + 위임체계 + nationwide comparison).
+    - `chain_procedure_detail(query)` — administrative procedure, 처리기한, 서식, 수수료.
+    - `chain_document_review(text, maxClauses?)` — contract/약관 clause-risk review of pasted text.
+    - `chain_full_research(query)` — fallback for vague natural-language questions (AI검색 + 법령 + 판례 + 해석례).
+
+    Meta (everything the 15 tools above do not cover):
+    - `discover_tools(intent)` — describe in words what you need (e.g. "행정규칙 검색", "조항호목 단위 조회", "법령 약칭 목록"); get back the specialist tool(s) that do it.
+    - `execute_tool(tool_name, params)` — run a tool that `discover_tools` returned.
+
+    Selection guide:
+    - "민법 750조 현행 조문" → `search_law("민법")` → `get_law_text(mst=..., jo="제750조")`.
+    - "음주운전 처벌 기준" (법령명 모름) → `chain_full_research(query="음주운전 처벌 기준")`, then cite the statute + 별표 (`get_annexes`).
+    - "전세 사기 대법원 판례" → `search_decisions(domain="precedent", query="전세 사기", options={"includeText": true})` → if needed `get_decision_text(domain="precedent", id=...)`.
+    - "헌재 양심적 병역거부 결정" → `search_decisions(domain="constitutional", query="양심적 병역거부")`.
+    - "이 답변/계약서에 인용된 조문 진짜 있어?" → `verify_citations(text=...)`.
+    - "민법 제103조 영향 범위" → `impact_map(lawName="민법", jo="제103조")`.
+    - "관세법 체계 전체" → `chain_law_system(query="관세법 체계")`.
+    - "이 임대차계약서 독소조항" → `chain_document_review(text=...)`.
+    - "행정규칙/자치법규 직접 조회" 또는 위 16개로 안 되는 기능 → `discover_tools(intent="...")` → `execute_tool(...)`.
+    </available_tools>
+
+    <handling_uncertainty>
+    1. If the USER's question is ambiguous in a way that changes which tool to call (e.g. "그 개정 언제야?" without naming the law, or "노동 사건" without saying 판례 vs 노동위 결정), ask one targeted clarifying question and stop. Do not call tools in the dark.
+    2. If a tool returns nothing, say so and propose two concrete next searches (broaden the keyword, try `search_ai_law`, drop a filter). Do not silently retry forever.
+    3. If the legal question is outside Korean (대한민국) jurisdiction (e.g. US, Japanese, or PRC law), say so directly and decline. Your sources are 대한민국 only.
+    4. You are not a licensed attorney (변호사). If the question asks for legal advice on the USER's own dispute, end with a one-line disclaimer recommending licensed counsel (변호사 상담 권유).
+    </handling_uncertainty>
+
+    <communication_style>
+    IMPORTANT: BE CONCISE. Legal readers value density. Minimize output tokens while preserving the citation, the holding, and the operative reasoning.
+    Refer to the USER in the second person and yourself in the first person. Mirror the USER's language (Korean or English).
+    Format responses in GitHub-flavored Markdown. Use `inline code` for 법령명, 조문 번호, `mst`/`lawId`, 사건번호, and 판례일련번호. Use headings only when the answer has more than one distinct holding or source.
+    Lead with the answer in one sentence. Then the citation. Then the reasoning. Then 출처.
+    Do not pad with niceties. Do not restate the USER's question. Do not say "as an AI".
+    </communication_style>
+    """
+)

--- a/examples/agno-bindu/requirements.txt
+++ b/examples/agno-bindu/requirements.txt
@@ -1,0 +1,15 @@
+# Python dependencies for the agno + Bindu glue in this example.
+#
+# The Korean-law MCP server itself is the Node/TypeScript project in the
+# parent directory — it is NOT a Python package. Build it once with
+# `npm install && npm run build` at the repo root (see README.md → Setup);
+# this example launches the built `build/index.js` over stdio.
+
+bindu>=2026.20
+agno>=2.6,<3
+openai>=1.40
+mcp>=1.0
+sqlalchemy>=2
+aiosqlite>=0.20
+python-dotenv>=1.0
+rich>=13


### PR DESCRIPTION
## What this pull request adds

This PR adds **one directory, `examples/agno-bindu/`**, plus two short pointer
lines in each of your READMEs (`README.md` and `README-EN.md`). The directory
is a complete, self-contained example showing how to take this MCP server and
expose it as a **network-addressable agent** over the
[A2A](https://github.com/google-a2a/A2A) (Agent-to-Agent) JSON-RPC protocol,
using [Bindu](https://github.com/GetBindu/Bindu) for the agent runtime and
[agno](https://github.com/agno-agi/agno) for the agent loop.

It is **additive and low-risk**: no code under `src/` is touched, your
`package.json` and CI are unchanged, and your build is untouched. The example's
Python dependencies live only in `examples/agno-bindu/requirements.txt` and are
opt-in. The MCP server itself is used **unmodified** — the example builds it
(`npm run build`) and launches `build/index.js` over stdio as a child process.

## Who is contributing this

Contributed by the team at [Bindu](https://github.com/GetBindu/Bindu), where we
are building a compliance operating system for small and medium businesses. The
agent in this directory ("Lex Korea") is one of the reference agents we ship,
and this PR is the result of integrating your server into our stack. Your
project is the source of the real capability here — the breadth of 법제처
coverage behind one MCP surface is what makes the agent possible — and we link
back to this repository from Bindu's docs and examples so discovery flows both
ways.

## How the example is shaped

- **`bindu_agent.py`** (primary entry point) exposes the agent over A2A. Bindu's
  handler contract is synchronous while agno's `MCPTools` is async-only, so the
  example runs one asyncio loop in a daemon thread, opens the MCP connection
  **once** at startup, and marshals each request onto that loop — a single warm
  `korean-law-mcp` subprocess serves every request instead of respawning per
  call.
- **`cli.py`** is a one-shot local runner for the same agent (no network).
- **`agent.py`** defines the agno `Agent` and the launch command. It passes
  `LAW_OC` through to the launched server explicitly via
  `StdioServerParameters(env=…)`, because the MCP stdio client does not forward
  arbitrary parent-process env vars.
- **`prompts.py`** is the system prompt (details below).

The agent has a DID-based identity and a public agent card, and answers in
Korean or English, mirroring the user.

## The API surface

With the service running (`uv run python examples/agno-bindu/bindu_agent.py`),
the endpoints at `http://localhost:3773` are:

- `GET /.well-known/agent.json` — the public agent card; the DID is published
  under `capabilities.extensions[].uri` (`did:bindu:…:bindu-lex-korea:…`).
- `GET /health` — health payload including `application.agent_did`.
- `POST /` — JSON-RPC 2.0: `message/send` (returns a task with state
  `submitted`) and `tasks/get` (poll until `completed`). Per the A2A spec a
  `message/send` carries four UUIDs (the JSON-RPC `id` plus `messageId`,
  `contextId`, `taskId`); the answer text lands at
  `result.artifacts[0].parts[0].text`.

Full request/response bodies and a copy-paste shell snippet are in
`examples/agno-bindu/README.md`.

## How the agent is instructed

The system prompt pins the agent to a few behaviours:

1. **MCP-first.** Every substantive answer about a Korean statute, precedent,
   interpretation, or tribunal decision must come from a tool call against your
   server, never the model's training memory.
2. **Cite every claim** — statutes by 법령명 + 조문 (and `mst`), cases by
   사건번호 / 판례일련번호, decisions by issuing body and number, with a
   Sources list.
3. **Cheapest precise call.** Resolve a 법령명 with `search_law` then
   `get_law_text`; reserve the `chain_*` orchestrators for genuinely
   multi-database questions; reach the specialist tribunals through
   `search_decisions(domain=…)`, and only drop to `discover_tools` /
   `execute_tool` for capabilities the directly-exposed tools don't cover.
4. **Decline out-of-scope and clarify ambiguity** — non-Korean-jurisdiction
   questions are declined with no tool call; genuinely ambiguous questions get
   one targeted clarifying question.

The prompt's tool cheat-sheet is written against your **17 exposed tools** (it
treats `discover_tools` / `execute_tool` as the gateway to the deeper
specialist tools, rather than assuming they are all top-level).

## End-to-end verification

Executed against the **live 법제처 국가법령정보 API** (via the local
`korean-law-mcp` server) during integration testing — each query run **both**
through `cli.py` and through the live A2A service. Model:
`anthropic/claude-sonnet-4.5` via OpenRouter.

| # | Capability (tool) | Question | Path | Outcome |
|---|---|---|---|---|
| 1 | Statute (`search_law`→`get_law_text`) | 민법 제750조의 현행 조문 | CLI + A2A | Returned 제750조(불법행위의 내용) verbatim, `MST 284415`, 시행 2026-03-17, cited. |
| 2 | 별표/서식 (`get_annexes`) | 산업안전보건법 시행규칙 [별표 1] | CLI + A2A | Returned the title (건설업체 산업재해발생률 산정 기준…) and 근거 조문 (제4조 관련). |
| 3 | Case law (`search_decisions` precedent) | 전세 사기 대법원 판례 + 요지 | CLI + A2A | Returned 대법원 2025. 5. 29. 선고 `2023다244871` (판례일련번호 `613097`) with a one-line holding. |
| 4 | Hallucination guard (`verify_citations`) | 민법 제750조 / 제9999조 검증 | CLI + A2A | Verified 제750조; flagged 제9999조 as non-existent (민법 ends at 제1118조). On A2A the tool hit a transient network blip and the agent fell back to a direct `get_law_text` check, reaching the same verdict. |
| 5 | Impact graph (`impact_map`) | 민법 제103조 영향 맵 | CLI + A2A | Returned 9 citing sources (대법원 1, 헌재 6, 자치법규 2) + a mermaid diagram. |
| 6 | Out-of-scope (no tool call) | "Most recent U.S. Supreme Court ruling on affirmative action?" | CLI + A2A | Declined politely, **no tool call**, pointed to Justia / SCOTUSblog / Oyez. |
| 7 | Ambiguous (no tool call) | "그 법 언제 개정됐어?" | CLI + A2A | Asked **one** clarifying question (which 법령?) in Korean — **no tool call**. |

Also confirmed: the agent card exposes a `did:bindu:…` under
`capabilities.extensions[].uri`; `/health` reports `health: healthy` and
`task_manager_running: true`; and a **single** `build/index.js` subprocess
served all seven A2A calls (the background loop keeps it warm).

## Test plan for review

All `uv`, no `pip`. From the repo root:

```bash
# 1. Build the MCP server (your normal build).
npm install && npm run build

# 2. Isolated Python env for the example glue.
uv venv
uv pip install -r examples/agno-bindu/requirements.txt

# 3. Credentials.
cp examples/agno-bindu/.env.example examples/agno-bindu/.env
#   set LAW_OC (your 법제처 key) and OPENROUTER_API_KEY

# 4. One-shot CLI.
uv run python examples/agno-bindu/cli.py "민법 제750조의 현행 조문은?"

# 5. A2A service + a request.
uv run python examples/agno-bindu/bindu_agent.py        # in one shell
curl -s http://localhost:3773/.well-known/agent.json | jq '.capabilities.extensions[0].uri'
curl -s http://localhost:3773/health | jq '.health'
#   then one message/send + tasks/get (see the README "Try it out" snippet)
```

## A note to the maintainers

This is additive, not a request for changes to your code. If you'd prefer a
different structure — moving the example to a separate repository under the
Bindu org, different README pointers, or anything else — we're glad to
accommodate. Thank you for open-sourcing this server; it's a remarkable piece
of work, and we hope this makes it easy for others to turn it into a
network-addressable agent.
