### PR TITLE
fix(annex): 조례 별표/서식 동일 bylSeq 충돌 시 별표종류로 구분

### DIFF
--- a/src/tools/annex.ts
+++ b/src/tools/annex.ts
@@ -148,7 +148,7 @@ export async function getAnnexes(
 
     // 별표 선택값 지정 시 → 해당 별표 파일 다운로드 + 텍스트 추출
     if (annexSelector) {
-      return await extractAnnexContent(filtered, annexSelector, normalizedLawName)
+      return await extractAnnexContent(filtered, annexSelector, normalizedLawName, input.knd)
     }
 
     // 별표 선택값 미지정 → 기존 목록 반환
@@ -163,10 +163,11 @@ export async function getAnnexes(
 async function extractAnnexContent(
   annexList: AnnexItem[],
   annexSelector: string,
-  normalizedLawName: string
+  normalizedLawName: string,
+  knd?: string
 ): Promise<{ content: Array<{ type: string, text: string }>, isError?: boolean }> {
-  // bylSeq / annexNo / lawName 내 힌트로 유연 매칭
-  const matched = findMatchingAnnex(annexList, annexSelector)
+  // bylSeq / annexNo / lawName 내 힌트로 유연 매칭 (별표/서식 구분 위해 knd 전달)
+  const matched = findMatchingAnnex(annexList, annexSelector, knd)
   if (!matched) {
     const availableBylSeq = annexList.map((a) => a.별표번호).filter(Boolean).slice(0, 20).join(", ")
     return notFoundResponse(
@@ -332,20 +333,51 @@ function parseLawNameAndHint(lawName: string): { normalizedLawName: string, anne
   }
 }
 
-function findMatchingAnnex(annexList: AnnexItem[], annexSelector: string): AnnexItem | undefined {
+/**
+ * 별표 선택값으로 항목 매칭.
+ *
+ * 자치법규 등에서 [별표 N]과 [별지 제N호서식]이 동일 별표번호(bylSeq)를 공유하는 경우가
+ * 있어, 번호만으로 find() 하면 목록 순서상 먼저 오는 항목(주로 서식)이 잘못 선택된다.
+ * (예: 서울특별시 건축 조례 — [별표4] 대지안의 공지기준 / [별지 제4호서식] 공개공지 관리대장이
+ *  모두 별표번호 000400을 가짐.)
+ * 따라서 번호가 일치하는 후보를 모두 모은 뒤, knd(별표/서식 의도)로 별표종류를 구분해
+ * 올바른 항목을 고른다. knd 미지정 시 표(별표)를 서식보다 우선한다.
+ */
+function findMatchingAnnex(
+  annexList: AnnexItem[],
+  annexSelector: string,
+  knd?: string
+): AnnexItem | undefined {
   const selectorCandidates = buildSelectorCandidates(annexSelector)
   const selectorNumbers = extractSelectorNumbers(annexSelector)
 
-  return annexList.find((annex: AnnexItem) => {
+  // 번호/제목으로 매칭되는 후보 "전체" 수집 (find → filter)
+  const matches = annexList.filter((annex: AnnexItem) => {
     const annexNum = String(annex.별표번호 || "").trim()
     const annexTitle = String(annex.별표명 || "")
-
     if (annexNum && selectorCandidates.has(annexNum)) {
       return true
     }
-
     return selectorNumbers.some((num) => titleMatchesAnnexNumber(annexTitle, num))
   })
+
+  if (matches.length === 0) return undefined
+  if (matches.length === 1) return matches[0]
+
+  // 별표번호 충돌 → 별표종류("별표"/"서식")로 구분
+  const isForm = (a: AnnexItem) => /서식/.test(String(a.별표종류 || ""))
+  const isTable = (a: AnnexItem) => /별표/.test(String(a.별표종류 || ""))
+
+  if (knd === "2" || knd === "4") {
+    // 서식을 명시적으로 요청
+    return matches.find(isForm) || matches[0]
+  }
+  if (knd === "1" || knd === "3") {
+    // 별표를 명시적으로 요청
+    return matches.find(isTable) || matches[0]
+  }
+  // knd 미지정/전체(5): 표(별표)를 서식보다 우선
+  return matches.find(isTable) || matches[0]
 }
 
 function buildSelectorCandidates(selector: string): Set<string> {


### PR DESCRIPTION
## 문제
자치법규(조례)에서 `[별표 N]`과 `[별지 제N호서식]`이 동일한 별표번호(`bylSeq`)를 공유할 때, `get_annexes`가 요청한 별표 대신 서식을 반환합니다.

**재현**: 서울특별시 건축 조례 — `[별표 4] 대지안의 공지기준`과 `[별지 제4호서식] 공개공지 등 관리대장`이 모두 `000400`을 가짐. `get_annexes(lawName="서울특별시 건축 조례", annexNo=4)` 호출 시 서식이 반환됨(`knd="1"`, `bylSeq="000400"`을 줘도 동일).

## 원인
`findMatchingAnnex()`가 `annexList.find(...)`로 번호만 보고 첫 매칭 항목을 반환. 목록 순서상 서식이 먼저 와서 선택됨. 호출부에서 `knd`(별표/서식 의도)가 전달되지 않아 구분에 활용되지 못함.

## 수정
- 호출부에서 `extractAnnexContent`에 `input.knd` 전달
- `extractAnnexContent` 시그니처에 `knd?` 추가
- `findMatchingAnnex`: 번호 일치 후보를 모두 수집(`filter`)한 뒤, 충돌 시 `별표종류`("별표"/"서식")로 구분. `knd` 1·3→별표, 2·4→서식, 미지정/5→별표 우선.

기존 함수(`buildSelectorCandidates`, `extractSelectorNumbers`, `titleMatchesAnnexNumber`)는 변경 없음.

## 검증
- `npm run build`(tsc), `npx tsc --noEmit` → 오류 0건
- 단위검증: annexNo=4(미지정)→별표, bylSeq=000400 knd=1→별표, knd=2→서식 모두 통과
- 변경 범위: `src/tools/annex.ts` 단일 파일, +40/-8

> 참고: 통합검증(실제 MCP 호출로 "대지안의 공지기준" 반환 확인)은 배포 후 확인 필요.