### PR TITLE
fix(v4.4.2): get_annexes 별표 의X 번호 파싱 버그 수정 + 플러그인 메타 현행화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "source": "github",
         "repo": "chrisryugj/korean-law-mcp"
       },
-      "description": "법제처 42개 API → 19개 MCP 도구. 법령·판례·조례·조약 검색 + LLM 환각 방지 인용 검증 + 조문 영향 그래프 + 시점 비교 + 판례 생사 확인(Citator) + 행위시법 판단",
+      "description": "법제처 42개 API → 9개 통합 도구. 법령·판례·행정규칙·자치법규·조약·해석례 + LLM 환각 방지 인용 검증 + 조문 영향 그래프 + 시점 비교 자동 diff + 판례 생사 확인(Citator) + 행위시법 판단 + 이럴 땐 이렇게 5단계 안내",
       "version": "4.4.1",
       "author": {
         "name": "Chris"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "korean-law",
   "version": "4.4.1",
-  "description": "법제처 42개 API → 17개 MCP 도구. 법령·판례·조례·조약 + LLM 환각 방지 인용 검증 + 조문 영향 그래프 + 시점 비교 diff + 상황별 5단계 안내",
+  "description": "법제처 42개 API → 9개 통합 도구. 법령·판례·행정규칙·자치법규·조약·해석례 + LLM 환각 방지 인용 검증 + 조문 영향 그래프 + 시점 비교 자동 diff + 판례 생사 확인(Citator) + 행위시법 판단 + 이럴 땐 이렇게 5단계 안내",
   "author": {
     "name": "Chris",
     "email": "ryuseungin@gmail.com",

--- a/src/tools/annex.ts
+++ b/src/tools/annex.ts
@@ -30,7 +30,7 @@ interface AnnexItem {
 const LAW_BASE_URL = getLawSiteBaseUrl()
 
 export const GetAnnexesSchema = z.object({
-  lawName: z.string().describe("법령명 (예: '관세법'). 별표를 바로 지정하려면 '... 별표4'처럼 함께 입력 가능"),
+  lawName: z.string().describe("법령명 (예: '관세법'). 별표를 바로 지정하려면 '... 별표4' 또는 '... 별표1의2'처럼 함께 입력 가능"),
   knd: z.enum(["1", "2", "3", "4", "5"]).optional().describe("1=별표, 2=서식, 3=부칙별표, 4=부칙서식, 5=전체"),
   bylSeq: z.string().optional().describe("별표번호 (예: '000300'). 지정 시 해당 별표 파일을 다운로드하여 텍스트로 추출"),
   annexNo: z.string().optional().describe("별표 번호 (예: '4', '별표4', '제4호'). bylSeq 대체 입력"),
@@ -314,21 +314,33 @@ function extractParentLawName(lawName: string): string | null {
 
 function parseLawNameAndHint(lawName: string): { normalizedLawName: string, annexNo?: string } {
   const trimmedLawName = lawName.trim()
-  const annexHintMatch = trimmedLawName.match(/\[?\s*(별표|서식)\s*(?:제)?\s*(\d{1,6})\s*(?:호)?\s*\]?/)
+  // "별표1", "별표 제1호", "별표 1의2"(= 별표 제1호의2) 모두 매칭. 의-번호는 별도 캡처해 법령명에 남지 않게 한다.
+  const annexHintMatch = trimmedLawName.match(/\[?\s*(별표|서식)\s*(?:제)?\s*(\d{1,6})\s*(?:호)?\s*(?:의\s*(\d{1,2}))?\s*\]?/)
 
   if (!annexHintMatch) {
     return { normalizedLawName: trimmedLawName }
   }
 
-  const parsedAnnexNo = Number.parseInt(annexHintMatch[2], 10)
+  const mainNo = Number.parseInt(annexHintMatch[2], 10)
+  const subNo = annexHintMatch[3] ? Number.parseInt(annexHintMatch[3], 10) : null
   const normalizedLawName = trimmedLawName
     .replace(annexHintMatch[0], " ")
     .replace(/\s+/g, " ")
     .trim()
 
+  if (Number.isNaN(mainNo)) {
+    return { normalizedLawName: normalizedLawName || trimmedLawName }
+  }
+
+  // 의-번호가 있으면 법제처 별표번호 6자리 코드(AAAABB)로 변환 (별표 1의2 → "000102").
+  // 없으면 기존 동작 유지(정수 문자열 → buildSelectorCandidates가 6자리 코드 후보 생성).
+  const annexNo = subNo != null
+    ? String(mainNo).padStart(4, "0") + String(subNo).padStart(2, "0")
+    : String(mainNo)
+
   return {
     normalizedLawName: normalizedLawName || trimmedLawName,
-    annexNo: Number.isNaN(parsedAnnexNo) ? undefined : String(parsedAnnexNo)
+    annexNo
   }
 }
 


### PR DESCRIPTION
## Summary

- **버그 수정**: `get_annexes`에 `별표1의2` 같은 의-번호를 `lawName` 힌트로 전달하면 `parseLawNameAndHint()` 정규식이 `별표1`만 떼어내고 `의2`를 법령명에 잔류시켜 `[NOT_FOUND]`로 실패하던 문제 수정
- **수정 방법**: 정규식에 `(?:의\s*(\d{1,2}))?` 캡처 그룹 추가 → 의-번호를 법제처 6자리 코드(`AAAABB`)로 직접 변환 (`별표1의2` → `000102`). 의-번호 없는 기존 형식은 동작 무변경
- **플러그인 메타**: `.claude-plugin/plugin.json`, `marketplace.json` 설명 문구를 v4.4.0 기준(9개 통합 도구)으로 현행화

## Test plan

- [x] `별표1의2` (공백 없음) → 별표 1의2 정상 반환 확인
- [x] `별표 1의2` (공백 포함) → 정상 반환 확인
- [x] `별표1` (기존 형식) → 무회귀 확인
- [ ] 국민건강보험법 시행규칙 별표1의2 등 실제 법령으로 end-to-end 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)