### PR TITLE
fix(utils): get_law_abbreviations 파싱 태그 불일치로 매 호출 실패하던 것 수정

### DIFF
--- a/src/tools/utils.test.ts
+++ b/src/tools/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { getLawAbbreviations } from "./utils.js"
+import type { LawApiClient } from "../lib/api-client.js"
+
+// 실제 lawSearch.do(target=lsAbrv) 응답 축약(2026-07 라이브 캡처 기준).
+// 항목 태그가 <lsAbrv>가 아니라 <law>이고, 필드는 법령명한글/법령약칭명이다.
+const LSABRV_XML = `<?xml version="1.0" encoding="UTF-8"?><LawSearch><target>lsAbrv</target><totalCnt>2686</totalCnt><page>1</page>
+<law id="1"><법령일련번호>253527</법령일련번호><현행연혁코드>현행</현행연혁코드><법령명한글><![CDATA[10ㆍ27법난 피해자의 명예회복 등에 관한 법률]]></법령명한글><법령약칭명>10ㆍ27법난법</법령약칭명><법령ID>010719</법령ID><공포일자>20230808</공포일자><소관부처명>문화체육관광부</소관부처명></law>
+<law id="2"><법령일련번호>253528</법령일련번호><현행연혁코드>현행</현행연혁코드><법령명한글><![CDATA[화학물질관리법]]></법령명한글><법령약칭명>화관법</법령약칭명><법령ID>000162</법령ID><공포일자>20240101</공포일자><소관부처명>환경부</소관부처명></law>
+</LawSearch>`
+
+const textOf = (r: { content: Array<{ text: string }> }) => r.content[0].text
+
+describe("getLawAbbreviations — 죽은 파싱 부활", () => {
+  // 종전 코드는 존재하지 않는 <lsAbrv> 태그를 찾다 0건 → 매 호출
+  // "약칭 데이터가 없습니다"(isError)만 반환했다. 실제 항목 태그는 <law>.
+  it("실제 응답 구조(<law> 항목)에서 약칭 목록을 파싱한다", async () => {
+    const client = {
+      fetchApi: async () => LSABRV_XML,
+    } as unknown as LawApiClient
+
+    const result = await getLawAbbreviations(client, {})
+    expect(result.isError).toBeUndefined()
+    const text = textOf(result)
+    expect(text).toContain("화학물질관리법 → 약칭: 화관법 (ID: 000162)")
+  })
+
+  it("총계는 조회 건수(2)가 아니라 법제처 totalCnt(2686)", async () => {
+    const client = {
+      fetchApi: async () => LSABRV_XML,
+    } as unknown as LawApiClient
+    const text = textOf(await getLawAbbreviations(client, {}))
+    expect(text).toContain("법령 약칭 목록 (총 2686건 중 2건 조회")
+  })
+
+  it("display=100을 API에 전달한다 (미전달 시 기본 20건 잘림)", async () => {
+    const captured: Array<Record<string, string>> = []
+    const client = {
+      fetchApi: async (p: { extraParams: Record<string, string> }) => {
+        captured.push(p.extraParams)
+        return LSABRV_XML
+      },
+    } as unknown as LawApiClient
+    await getLawAbbreviations(client, {})
+    expect(captured[0].display).toBe("100")
+  })
+})

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -8,6 +8,7 @@ import type { LawApiClient } from "../lib/api-client.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { buildJO, buildOrdinanceJO, formatJO } from "../lib/law-parser.js"
 import { formatToolError } from "../lib/errors.js"
+import { extractTag } from "../lib/xml-parser.js"
 
 export const ParseJoCodeSchema = z.object({
   joText: z.string().describe("변환할 조문 번호 (예: '제38조', '10조의2', '003800', '010000')"),
@@ -69,7 +70,9 @@ export async function getLawAbbreviations(
   input: GetLawAbbreviationsInput
 ): Promise<{ content: Array<{ type: string, text: string }>, isError?: boolean }> {
   try {
-    const extraParams: Record<string, string> = {}
+    const extraParams: Record<string, string> = {
+      display: "100", // 최대 100개 — 미전달 시 법제처 기본 20건만 조회됨
+    }
     if (input.stdDt) extraParams.stdDt = String(input.stdDt)
     if (input.endDt) extraParams.endDt = String(input.endDt)
 
@@ -84,7 +87,9 @@ export async function getLawAbbreviations(
     const parser = new DOMParser()
     const doc = parser.parseFromString(xmlText, "text/xml")
 
-    const items = doc.getElementsByTagName("lsAbrv")
+    // 실제 응답의 항목 태그는 <law>다 (<lsAbrv>는 target명일 뿐 요소로 존재하지 않음).
+    // 종전엔 lsAbrv를 찾다 0건 → 매 호출 "약칭 데이터가 없습니다" 오류만 반환했다.
+    const items = doc.getElementsByTagName("law")
     if (items.length === 0) {
       return {
         content: [{ type: "text", text: "약칭 데이터가 없습니다." }],
@@ -92,13 +97,19 @@ export async function getLawAbbreviations(
       }
     }
 
-    let resultText = `법령 약칭 목록 (총 ${items.length}건):\n\n`
+    // "총 N건"은 법제처 totalCnt(실측 2,600건+) — 조회 건수를 총계로 쓰면 잘림이 전량으로 위장된다
+    const totalCnt = Math.max(parseInt(extractTag(xmlText, "totalCnt") || "0", 10) || 0, items.length)
+
+    let resultText = `법령 약칭 목록 (총 ${totalCnt}건`
+    if (totalCnt > items.length) {
+      resultText += ` 중 ${items.length}건 조회 — 기간(stdDt/endDt)으로 좁혀 재조회 가능`
+    }
+    resultText += `):\n\n`
 
     for (let i = 0; i < items.length; i++) {
       const item = items[i]
-      const lawName = item.getElementsByTagName("법령명")[0]?.textContent || ""
-      const abbr = item.getElementsByTagName("약칭명")[0]?.textContent
-        || item.getElementsByTagName("약칭")[0]?.textContent || ""
+      const lawName = item.getElementsByTagName("법령명한글")[0]?.textContent || ""
+      const abbr = item.getElementsByTagName("법령약칭명")[0]?.textContent || ""
       const lawId = item.getElementsByTagName("법령ID")[0]?.textContent || ""
 
       if (lawName || abbr) {


### PR DESCRIPTION
## 증상

`get_law_abbreviations`가 **모든 호출에서** "약칭 데이터가 없습니다"(isError)를 반환합니다. 파라미터와 무관하게 항상 실패합니다.

## 원인 (실측)

`lawSearch.do?target=lsAbrv`의 실제 응답에서 항목 태그는 `<law>`인데, 코드는 존재하지 않는 `<lsAbrv>` 태그를 찾습니다:

```xml
<LawSearch><target>lsAbrv</target><totalCnt>2686</totalCnt>
<law id="1"><법령명한글><![CDATA[10ㆍ27법난 피해자의 명예회복 등에 관한 법률]]></법령명한글>
<법령약칭명>10ㆍ27법난법</법령약칭명><법령ID>010719</법령ID>…</law>
```

`getElementsByTagName("lsAbrv")`가 매번 0건 → 오류 경로로 직행. 필드명도 실응답과 불일치했습니다(`법령명`/`약칭명` → 실제는 `법령명한글`/`법령약칭명`).

## 수정

- 항목 태그 `lsAbrv` → `law`, 필드 `법령명한글`/`법령약칭명`으로 교체 (실응답 기준)
- `display=100` 전달 (미전달 시 기본 페이지만 조회되는 타깃 대비)
- "총 N건"을 응답의 `totalCnt`로 보고, 잘린 경우 "중 N건 조회" 병기

## 검증

- 실 API 호출: 약칭 목록 정상 반환 (총 2,686건) 확인
- 회귀 테스트 3건 추가 — 픽스처는 실응답 캡처 기반 (합성 픽스처로는 이 부류의 태그 불일치가 재현되지 않아 실형상을 사용했습니다)
- `npm run typecheck`·`npm test`·`npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)