### PR TITLE
fix(law-tree,linkage): 연계 3종 루트 태그 불일치로 항상 0건·law_tree 빈 트리 수정

### DIFF
--- a/src/tools/law-linkage.test.ts
+++ b/src/tools/law-linkage.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+import { getDelegatedLaws, getLinkedLawsFromOrdinance } from "./law-linkage.js"
+import type { LawApiClient } from "../lib/api-client.js"
+
+// 실측 응답 축약: lnkDep의 루트는 소문자 시작 lnkDepSearch, 항목 태그는 law.
+// 종전 코드는 LawSearch→LnkDepSearch(대문자)만 시도해 매 호출 0건이었다.
+const LNKDEP_XML = `<?xml version="1.0" encoding="UTF-8"?><lnkDepSearch><target>lnkDep</target><section>lsNm</section><totalCnt>107792</totalCnt><page>1</page>
+<law id="1"><법령명한글>119구조ㆍ구급에 관한 법률 시행령</법령명한글><법령ID>011452</법령ID><자치법규명><![CDATA[강원특별자치도 119구급상황관리센터 설치 및 운영 규칙]]></자치법규명><자치법규ID>2161837</자치법규ID><공포일자>20250605</공포일자></law>
+<law id="2"><법령명한글>관세법 시행령</법령명한글><법령ID>001590</법령ID><자치법규명><![CDATA[부산광역시 보세구역 운영 조례]]></자치법규명><자치법규ID>999001</자치법규ID><공포일자>20240101</공포일자></law>
+</lnkDepSearch>`
+
+const LNKORD_XML = `<?xml version="1.0" encoding="UTF-8"?><OrdinSearch><totalCnt>7</totalCnt><page>1</page>
+<law id="1"><자치법규명><![CDATA[서울특별시 경관 조례]]></자치법규명><법령명한글>경관법</법령명한글><법령ID>009682</법령ID></law>
+</OrdinSearch>`
+
+const stub = (xml: string) => ({ fetchApi: async () => xml }) as unknown as LawApiClient
+
+describe("law-linkage — 루트 태그 실형상 파싱 부활", () => {
+  it("lnkDep: 소문자 루트(lnkDepSearch)를 파싱하고 페이지 내 클라이언트 필터+한계 명시", async () => {
+    const r = await getDelegatedLaws(stub(LNKDEP_XML), { query: "관세법", display: 20, page: 1 })
+    const t = r.content[0].text
+    expect(r.isError).toBeUndefined()
+    expect(t).toContain("관세법 시행령")           // 매칭 행만
+    expect(t).not.toContain("119구조")             // 무관 행 제외
+    expect(t).toContain("매칭 1건")
+    expect(t).toContain("검색 필터를 지원하지 않아")  // 전수 아님 명시
+    expect(t).toContain("get_linked_ordinances")     // 대안 유도
+  })
+
+  it("lnkDep: 페이지 내 매칭 0건이어도 부재 단정 대신 범위 한계 안내", async () => {
+    const r = await getDelegatedLaws(stub(LNKDEP_XML), { query: "소득세법", display: 20, page: 1 })
+    const t = r.content[0].text
+    expect(r.isError).toBe(true)
+    expect(t).toContain("매칭 없음")
+    expect(t).toContain("전수 결과가 아닙니다")
+  })
+
+  it("lnkOrd: 실측 루트 OrdinSearch 파싱 (종전 LnkOrdSearch 가정으로 0건)", async () => {
+    const r = await getLinkedLawsFromOrdinance(stub(LNKORD_XML), { query: "서울특별시 경관 조례", display: 20, page: 1 })
+    expect(r.isError).toBeUndefined()
+    expect(r.content[0].text).toContain("경관법")
+  })
+})

--- a/src/tools/law-linkage.ts
+++ b/src/tools/law-linkage.ts
@@ -28,7 +28,9 @@ export const LinkedOrdinanceArticlesSchema = baseLinkageSchema.extend({
   query: z.string().describe("법령명 (예: '국민건강보험법')")
 })
 export const DelegatedLawsSchema = baseLinkageSchema.extend({
-  query: z.string().describe("부처명 (예: '보건복지부')")
+  // 실측: lnkDep은 서버측 검색 필터가 없다(query 무시, 전체 덤프+페이징만).
+  // 조회 페이지 내 클라이언트 필터만 가능 — 법령 기준 연계는 get_linked_ordinances 권장.
+  query: z.string().describe("필터 키워드(법령명 등) — ⚠️ 법제처가 이 목록의 서버측 검색을 지원하지 않아 조회 페이지 내 부분 필터만 됩니다. 법령 기준 자치법규 연계는 get_linked_ordinances 사용 권장")
 })
 export const LinkedLawsFromOrdinanceSchema = baseLinkageSchema.extend({
   query: z.string().describe("자치법규명 (예: '서울특별시 주차장 설치 및 관리 조례')")
@@ -37,7 +39,10 @@ export const LinkedLawsFromOrdinanceSchema = baseLinkageSchema.extend({
 // === 범용 XML 파서 (응답 구조 미확정 대응) ===
 
 function parseLinkageXML(xml: string, rootTag: string, itemTag: string) {
-  const rootRegex = new RegExp(`<${rootTag}[^>]*>([\\s\\S]*?)<\\/${rootTag}>`)
+  // 루트 태그는 대소문자 무시로 매칭 — 실측상 lnkDepSearch·lnkOrdJoSearch처럼
+  // 소문자로 시작해, 대문자 시작을 가정한 종전 코드는 3/4 타깃에서 루트 매칭에
+  // 실패해 매 호출 0건(NOT_FOUND)이었다.
+  const rootRegex = new RegExp(`<${rootTag}[^>]*>([\\s\\S]*?)<\\/${rootTag}>`, "i")
   const rootMatch = xml.match(rootRegex)
   if (!rootMatch) return { totalCnt: 0, page: 1, items: [] as Record<string, string>[] }
 
@@ -77,6 +82,8 @@ interface LinkageConfig {
   fallbackRoot: string
   title: string
   emptyMsg: string
+  /** 서버가 query 필터를 지원하지 않는 전체 덤프 타깃 (실측: lnkDep 총 10만+건, query 무시) */
+  serverFilterless?: boolean
 }
 
 type LinkageInput = z.infer<typeof baseLinkageSchema>
@@ -86,7 +93,12 @@ async function handleLinkage(apiClient: LawApiClient, input: LinkageInput, cfg: 
     const xml = await apiClient.fetchApi({
       endpoint: "lawSearch.do",
       target: cfg.target,
-      extraParams: { query: String(input.query), display: String(input.display || 20), page: String(input.page || 1) },
+      extraParams: {
+        query: String(input.query),
+        // 필터 미지원 타깃은 클라이언트 필터 풀을 최대로 (API 상한 100)
+        display: cfg.serverFilterless ? "100" : String(input.display || 20),
+        page: String(input.page || 1),
+      },
       apiKey: input.apiKey,
     })
 
@@ -100,6 +112,30 @@ async function handleLinkage(apiClient: LawApiClient, input: LinkageInput, cfg: 
         content: [{ type: "text", text: truncateResponse(`[NOT_FOUND] '${input.query}' ${cfg.emptyMsg}\n⚠️ LLM은 연계 정보를 추측/생성하지 마세요.`) }],
         isError: true
       }
+    }
+
+    if (cfg.serverFilterless) {
+      // 서버가 query를 무시하고 전체 목록을 돌려주는 타깃 — 조회분을 그대로 내보내면
+      // 무관한 행들이 "검색 결과"로 위장된다. 조회 페이지 내 클라이언트 필터 + 한계 명시.
+      const qKey = String(input.query).replace(/\s+/g, "")
+      const fetched = result.items.length
+      const matched = qKey
+        ? result.items.filter(it => Object.values(it).some(v => v.replace(/\s+/g, "").includes(qKey)))
+        : result.items
+
+      const scopeNote = `⚠️ 법제처가 이 목록(서버 전체 ${result.totalCnt}건)의 검색 필터를 지원하지 않아, 조회한 ${result.page}페이지(${fetched}건) 안에서만 '${input.query}'를 필터했습니다 — 전수 결과가 아닙니다.\n` +
+        `💡 법령 기준 자치법규 연계는 서버 필터가 지원되는 get_linked_ordinances(query="법령명")를 사용하세요.`
+
+      if (matched.length === 0) {
+        return {
+          content: [{ type: "text", text: truncateResponse(`[NOT_FOUND] 조회한 ${result.page}페이지(${fetched}건) 내 '${input.query}' 매칭 없음.\n${scopeNote}`) }],
+          isError: true
+        }
+      }
+      let output = `${cfg.title} (조회 ${result.page}페이지 ${fetched}건 중 '${input.query}' 매칭 ${matched.length}건)\n\n`
+      output += formatItems(matched)
+      output += `\n\n${scopeNote}`
+      return { content: [{ type: "text", text: truncateResponse(output) }] }
     }
 
     let output = `${cfg.title} (총 ${result.totalCnt}건, ${result.page}페이지)\n`
@@ -121,18 +157,22 @@ export const getLinkedOrdinances = (apiClient: LawApiClient, input: LinkageInput
 
 export const getLinkedOrdinanceArticles = (apiClient: LawApiClient, input: LinkageInput) =>
   handleLinkage(apiClient, input, {
-    target: "lnkLsOrdJo", primaryRoot: "LawSearch", fallbackRoot: "LnkLsOrdJoSearch",
+    // 실측 루트는 lnkOrdJoSearch (LnkLsOrdJoSearch 아님 — 이름 자체가 달랐다)
+    target: "lnkLsOrdJo", primaryRoot: "lnkOrdJoSearch", fallbackRoot: "LawSearch",
     title: "법령-자치법규 조문 연계", emptyMsg: "조문 연계 결과가 없습니다."
   })
 
 export const getDelegatedLaws = (apiClient: LawApiClient, input: LinkageInput) =>
   handleLinkage(apiClient, input, {
-    target: "lnkDep", primaryRoot: "LawSearch", fallbackRoot: "LnkDepSearch",
-    title: "위임법령 목록", emptyMsg: "위임법령이 없습니다."
+    // 실측 루트는 lnkDepSearch — 종전 대문자 가정(LnkDepSearch)으로 매 호출 0건이었다
+    target: "lnkDep", primaryRoot: "lnkDepSearch", fallbackRoot: "LawSearch",
+    title: "위임 연계 자치법규 목록", emptyMsg: "위임 연계 자치법규가 없습니다.",
+    serverFilterless: true
   })
 
 export const getLinkedLawsFromOrdinance = (apiClient: LawApiClient, input: LinkageInput) =>
   handleLinkage(apiClient, input, {
-    target: "lnkOrd", primaryRoot: "LawSearch", fallbackRoot: "LnkOrdSearch",
+    // 실측 루트는 OrdinSearch (LnkOrdSearch 아님)
+    target: "lnkOrd", primaryRoot: "OrdinSearch", fallbackRoot: "LawSearch",
     title: "자치법규 → 상위법령", emptyMsg: "상위법령이 없습니다."
   })

--- a/src/tools/law-tree.test.ts
+++ b/src/tools/law-tree.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { parseThreeTierText, GetLawTreeSchema } from "./law-tree.js"
+
+// get_three_tier(관세법) 실측 출력 축약 (2026-07 라이브 캡처).
+// 종전 스크래퍼는 존재하지 않는 "법률명:"·"법률 조항"·"시행령 조항" 헤더를 찾아
+// 유효 입력에도 빈 트리를 반환했다.
+const THREE_TIER_TEXT = `법령명: 관세법
+
+---
+제4조 제4조(내국세등의 부과ㆍ징수)
+---
+
+[시행령] 관세법 시행령 제1조의2 (체납된 내국세등의 세무서장 징수)
+①  「관세법」(이하 "법"이라 한다) 제4조제2항에 따라 …
+   (위임 내용 862자 중 일부만 표시)
+
+---
+제5조
+---
+
+[시행령] 관세법 시행령 제1조의3 (관세법 해석에 관한 질의회신의 절차와 방법)
+①  재정경제부장관 및 관세청장은 …
+
+[시행규칙] 관세법 시행규칙 제2조 (기한의 계산)
+① 법 제8조제3항에서 …
+`
+
+describe("parseThreeTierText — 실측 형식 스크래핑", () => {
+  it("법령명·법률/시행령/시행규칙 조문을 추출한다 (종전엔 전부 빈 배열)", () => {
+    const r = parseThreeTierText(THREE_TIER_TEXT)
+    expect(r.lawName).toBe("관세법")
+    expect(r.law).toEqual(["제4조", "제5조"])
+    expect(r.decree).toEqual(["제1조의2", "제1조의3"])
+    expect(r.rule).toEqual(["제2조"])
+  })
+})
+
+describe("GetLawTreeSchema — 빈 입력 가드", () => {
+  // 종전엔 빈 입력이 API까지 가서 13초 뒤 "Unexpected end of JSON input"으로 죽었다
+  it("mst/lawId 둘 다 없으면 스키마에서 거부", () => {
+    expect(GetLawTreeSchema.safeParse({}).success).toBe(false)
+    expect(GetLawTreeSchema.safeParse({ mst: "280363" }).success).toBe(true)
+  })
+})

--- a/src/tools/law-tree.ts
+++ b/src/tools/law-tree.ts
@@ -13,9 +13,60 @@ export const GetLawTreeSchema = z.object({
   mst: z.string().optional().describe("법령일련번호"),
   lawId: z.string().optional().describe("법령ID"),
   apiKey: z.string().optional().describe("법제처 Open API 인증키(OC). 사용자가 제공한 경우 전달")
+}).refine(data => data.mst || data.lawId, {
+  // 빈 입력이 그대로 API까지 가서 13초 뒤 "Unexpected end of JSON input"으로
+  // 죽던 것 방지 — 형제 도구(get_three_tier)와 동일한 가드
+  message: "mst 또는 lawId 중 하나는 필수입니다"
 })
 
 export type GetLawTreeInput = z.infer<typeof GetLawTreeSchema>
+
+/**
+ * get_three_tier 텍스트 출력에서 트리 구조 추출.
+ * 실제 출력 형식(실측): "법령명: X" 헤더, "---" 구분선 사이의 "제N조 …" 법률 조문,
+ * "[시행령] …제N조의M (제목)" / "[시행규칙] …" 위임 라인.
+ * (종전 코드는 존재하지 않는 "법률명:"·"법률 조항"·"시행령 조항" 헤더를 찾아
+ *  유효 입력에도 빈 트리를 반환했다.)
+ */
+export function parseThreeTierText(text: string): {
+  lawName: string
+  law: string[]
+  decree: string[]
+  rule: string[]
+} {
+  const lines = text.split("\n")
+  let lawName = ""
+  const law: string[] = []
+  const decree: string[] = []
+  const rule: string[] = []
+  const seen = { law: new Set<string>(), decree: new Set<string>(), rule: new Set<string>() }
+
+  const pushUnique = (bucket: string[], set: Set<string>, article: string) => {
+    if (!set.has(article)) { set.add(article); bucket.push(article) }
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    const nameMatch = trimmed.match(/^법(?:령|률)명:\s*(.+)$/)
+    if (nameMatch) { lawName = nameMatch[1].trim(); continue }
+
+    const articleRe = /제\d+조(?:의\d+)?/
+    if (trimmed.startsWith("[시행령]")) {
+      const m = trimmed.match(articleRe)
+      if (m) pushUnique(decree, seen.decree, m[0])
+    } else if (trimmed.startsWith("[시행규칙]")) {
+      const m = trimmed.match(articleRe)
+      if (m) pushUnique(rule, seen.rule, m[0])
+    } else if (/^제\d+조(의\d+)?(\s|$)/.test(trimmed)) {
+      // 법률 조문 헤더 라인 ("제4조 제4조(내국세등의 부과ㆍ징수)" 형태)
+      const m = trimmed.match(articleRe)
+      if (m) pushUnique(law, seen.law, m[0])
+    }
+  }
+  return { lawName, law, decree, rule }
+}
 
 export async function getLawTree(
   apiClient: LawApiClient,
@@ -35,40 +86,19 @@ export async function getLawTree(
     }
 
     const text = result.content[0].text
+    const parsed = parseThreeTierText(text)
+    const lawName = parsed.lawName
+    const structure = { law: parsed.law, decree: parsed.decree, rule: parsed.rule }
 
-    // Parse the three-tier result to extract law structure
-    // The result contains sections like "법률 조항", "시행령 조항", "시행규칙 조항"
-    const lines = text.split('\n')
-
-    let lawName = ""
-    let currentSection = ""
-    const structure: {
-      law: Array<string>
-      decree: Array<string>
-      rule: Array<string>
-    } = {
-      law: [],
-      decree: [],
-      rule: []
-    }
-
-    for (const line of lines) {
-      if (line.includes('법률명:')) {
-        lawName = line.replace('법률명:', '').trim()
-      } else if (line.includes('법률 조항')) {
-        currentSection = "law"
-      } else if (line.includes('시행령 조항')) {
-        currentSection = "decree"
-      } else if (line.includes('시행규칙 조항')) {
-        currentSection = "rule"
-      } else if (line.trim() && currentSection) {
-        // Extract article references
-        const articleMatch = line.match(/제\d+조(의\d+)?/)
-        if (articleMatch) {
-          if (currentSection === "law") structure.law.push(articleMatch[0])
-          else if (currentSection === "decree") structure.decree.push(articleMatch[0])
-          else if (currentSection === "rule") structure.rule.push(articleMatch[0])
-        }
+    if (structure.law.length === 0 && structure.decree.length === 0 && structure.rule.length === 0) {
+      // 위임조문 데이터가 없거나 형식이 예상과 다른 경우 — 빈 껍데기 트리를
+      // 정상 결과처럼 내보내지 않는다
+      return {
+        content: [{
+          type: "text",
+          text: `[NOT_FOUND] ${lawName || "해당 법령"}의 위임조문 트리를 구성할 데이터가 없습니다.\n⚠️ LLM은 법령 체계를 추측하지 마세요. get_three_tier로 원본 위임조문을 직접 확인하세요.`,
+        }],
+        isError: true,
       }
     }
 


### PR DESCRIPTION
## 증상

연계 도구 4종 중 3종이 **모든 호출에서** NOT_FOUND를 반환합니다:

- `get_delegated_laws` · `get_linked_ordinance_articles` · `get_linked_laws_from_ordinance` → 항상 0건
- `get_law_tree` → 유효한 mst를 줘도 조항이 하나도 없는 빈 트리 반환, mst/lawId 없이 부르면 13초 후 `Unexpected end of JSON input`

## 원인 (실측)

**1) 루트 태그 불일치** — 4개 타깃의 실제 응답 루트를 각각 확인한 결과:

| target | 코드가 찾는 루트 | 실제 루트 |
|---|---|---|
| lnkLs | `LawSearch` | `LawSearch` ✓ (유일하게 생존) |
| lnkLsOrdJo | `LnkLsOrdJoSearch` | `lnkOrdJoSearch` (이름 자체가 다름) |
| lnkDep | `LnkDepSearch` | `lnkDepSearch` (소문자 시작) |
| lnkOrd | `LnkOrdSearch` | `OrdinSearch` (전혀 다름) |

**2) `lnkDep`은 서버측 검색 필터가 없음** — query를 무시하고 전체 목록(10만+건)을 반환합니다 (`query`/`lsNm`/`LM`/`knd` 변형 모두 무효 확인). 스키마 설명("부처명")도 실동작과 무관했습니다.

**3) `get_law_tree`는 `get_three_tier` 출력을 존재하지 않는 헤더로 스크래핑** — `"법률명:"`·`"법률 조항"`·`"시행령 조항"`을 찾지만 실제 출력은 `"법령명:"` 헤더와 `[시행령]`·`[시행규칙]` 인라인 마커 형식이라 항상 빈 구조가 됩니다.

## 수정

- 실측 루트 태그로 교체 + 루트 매칭을 대소문자 무시로 변경 (향후 표기 변동 방어)
- `get_delegated_laws`: 조회 페이지(100건) 내 클라이언트 필터로 전환하고 **"서버가 검색 필터를 지원하지 않아 전수 결과가 아님"을 응답에 명시**, 서버 필터가 지원되는 `get_linked_ordinances` 사용을 안내. 매칭 0건도 "부재"로 단정하지 않음
- `get_law_tree`: 실제 출력 형식 기준으로 파서 재작성(`parseThreeTierText`로 추출해 테스트), 빈 입력은 `get_three_tier`와 동일한 스키마 refine으로 즉시 거부, 데이터 없으면 빈 트리 대신 NOT_FOUND

## 검증

- 실 API: `get_law_tree`(관세법) 트리 정상 구성 / `lnkLsOrdJo`(주차장법) 8,874건 / `lnkOrd`(서울특별시 경관 조례 → 경관법) 7건 / `lnkDep` 페이지 내 매칭 71건 정직 표기
- 회귀 테스트 5건 추가 (실응답 캡처 픽스처)
- `npm run typecheck`·`npm test`·`npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)