### PR TITLE
fix(parsing): 연혁 페이징 조기종료·NaN 정렬·조문 출력 훼손·21항+ 미지원 수정

### DIFF
--- a/src/lib/article-parser.test.ts
+++ b/src/lib/article-parser.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { parseHangNumber } from "./article-parser.js"
+
+describe("parseHangNumber — 원숫자 21항 이상", () => {
+  // 회귀: ①~⑳까지만 매핑해 ㉑+(다른 유니코드 블록)가 NaN → verify_citations가
+  // 실존하는 제21항 인용을 "존재하지 않는 항"(HALLUCINATION_DETECTED)으로 오판했다.
+  it("㉑~㊿ 원숫자를 파싱한다", () => {
+    expect(parseHangNumber("㉑")).toBe(21)
+    expect(parseHangNumber("㉟")).toBe(35)
+    expect(parseHangNumber("㊱")).toBe(36)
+    expect(parseHangNumber("㊿")).toBe(50)
+  })
+
+  it("기존 ①~⑳·일반 숫자 동작 유지", () => {
+    expect(parseHangNumber("①")).toBe(1)
+    expect(parseHangNumber("⑳")).toBe(20)
+    expect(parseHangNumber("제3항")).toBe(3)
+    expect(parseHangNumber("")).toBeNaN()
+  })
+})

--- a/src/lib/article-parser.ts
+++ b/src/lib/article-parser.ts
@@ -132,7 +132,10 @@ export function formatArticleUnit(unit: {
  * 법제처 API는 항번호를 원숫자(①②③…)로 돌려주는 경우가 많아 일반 숫자 추출만 하면 NaN.
  * 원숫자 ①=1 … ⑳=20 매핑 + fallback으로 일반 숫자 추출.
  */
-const CIRCLED_DIGITS = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳"
+// ①~⑳(U+2460~) 뒤로 ㉑~㉟(U+3251~)·㊱~㊿(U+32B1~)는 다른 유니코드 블록 —
+// ⑳에서 끊으면 제21항 이상의 실존 인용이 NaN이 되어 verify_citations가
+// "존재하지 않는 항"([HALLUCINATION_DETECTED])으로 오판한다.
+const CIRCLED_DIGITS = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳㉑㉒㉓㉔㉕㉖㉗㉘㉙㉚㉛㉜㉝㉞㉟㊱㊲㊳㊴㊵㊶㊷㊸㊹㊺㊻㊼㊽㊾㊿"
 
 export function parseHangNumber(raw: unknown): number {
   const s = String(raw ?? "").trim()

--- a/src/lib/historical-utils.test.ts
+++ b/src/lib/historical-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest"
+import { fetchHistoricalVersionsFull } from "./historical-utils.js"
+import type { LawApiClient } from "./api-client.js"
+
+/** lsHistory HTML 행 생성 — parseHistoryRows의 ROW_PATTERN/필드 정규식에 맞춤 */
+const row = (lawNm: string, mst: number, efYd: string) =>
+  `<tr><td><a href="/lsInfoP.do?MST=${mst}&efYd=${efYd}">${lawNm}</a></td><td>제${mst}호</td><td>${efYd.slice(0, 4)}.${efYd.slice(4, 6)}.${efYd.slice(6, 8)}</td><td>일부개정</td></tr>`
+
+const pageHtml = (totalCount: number, rows: string[]) =>
+  `<html><body><strong>${totalCount}</strong> 건<table>${rows.join("\n")}</table></body></html>`
+
+describe("fetchHistoricalVersionsFull — 페이징 종료 판정", () => {
+  // 회귀: 종료 판정이 "필터 후 행수 < pageSize"였다.
+  // 1페이지 원시 500행(대부분 시행령·규칙)이 본법 몇 건으로 필터링되면
+  // 500 미만이라 즉시 종료 → 2페이지의 옛 본법 버전이 통째로 누락됐다.
+  it("필터 후 행수가 적어도 원시 총계만큼 페이지를 끝까지 훑는다", async () => {
+    // 원시 총 4행, pageSize=2 → 2페이지. 각 페이지에 본법 1행 + 시행령 1행(필터 대상).
+    const page1 = pageHtml(4, [
+      row("소득세법", 900, "20200101"),
+      row("소득세법 시행령", 901, "20200102"),
+    ])
+    const page2 = pageHtml(4, [
+      row("소득세법", 800, "20100101"),   // ← 옛 본법 버전 (종전 코드에선 도달 못함)
+      row("소득세법 시행령", 801, "20100102"),
+    ])
+    const served: string[] = []
+    const client = {
+      fetchApi: async (p: { extraParams: Record<string, string> }) => {
+        served.push(p.extraParams.page)
+        return p.extraParams.page === "1" ? page1 : page2
+      },
+    } as unknown as LawApiClient
+
+    const r = await fetchHistoricalVersionsFull(client, "소득세법", undefined, 2)
+    expect(served).toEqual(["1", "2"])
+    expect(r.versions.map(v => v.mst)).toEqual(["900", "800"])  // 시행일 내림차순, 옛 버전 포함
+    expect(r.fetchedPages).toBe(2)
+  })
+
+  it("마지막 페이지에서 정확히 멈춘다 (원시 총계 기준)", async () => {
+    const page1 = pageHtml(2, [row("상법", 500, "20200101"), row("상법", 400, "20100101")])
+    let calls = 0
+    const client = {
+      fetchApi: async () => { calls++; return page1 },
+    } as unknown as LawApiClient
+
+    const r = await fetchHistoricalVersionsFull(client, "상법", undefined, 2)
+    expect(calls).toBe(1)          // 2행 = 총계 2 → 1페이지로 종료
+    expect(r.versions).toHaveLength(2)
+  })
+
+  it("총계 파싱 실패 시 빈 페이지에서 보수적으로 종료 (무한루프 방지)", async () => {
+    const noTotal = `<html><body><table>${row("상법", 500, "20200101")}</table></body></html>`
+    const empty = `<html><body><table></table></body></html>`
+    let calls = 0
+    const client = {
+      fetchApi: async () => { calls++; return calls === 1 ? noTotal : empty },
+    } as unknown as LawApiClient
+
+    const r = await fetchHistoricalVersionsFull(client, "상법", undefined, 2)
+    expect(calls).toBeLessThanOrEqual(2)
+    expect(r.versions).toHaveLength(1)
+  })
+})

--- a/src/lib/historical-utils.ts
+++ b/src/lib/historical-utils.ts
@@ -98,14 +98,18 @@ export async function fetchHistoricalVersionsFull(
     if (page === 1) totalCount = parseTotalCount(html)
     const pageRows = parseHistoryRows(html, normalizedTarget, targetHasDecree)
     fetchedPages = page
-
-    if (pageRows.length === 0) break
     allVersions.push(...pageRows)
 
-    // 첫 페이지에 totalCount 다 들어왔으면 종료
-    if (totalCount > 0 && allVersions.length >= totalCount) break
-    // pageSize보다 적게 왔으면 끝
-    if (pageRows.length < pageSize) break
+    // 종료 판정은 원시 총계(totalCount) 기준이어야 한다. pageRows는 대상 법령명으로
+    // 필터링된 부분집합이라 "filtered < pageSize" 비교는 원시 행이 다음 페이지에
+    // 남아 있어도 1페이지에서 끊는다 — 본법+시행령·규칙 연혁 합계가 500행을 넘는
+    // 법령(소득세법류)에서 옛 본법 버전이 통째로 누락되어 applicable_law의
+    // 행위시법 버전 특정이 최신 쪽으로 어긋나던 원인.
+    if (totalCount > 0) {
+      if (page * pageSize >= totalCount) break   // 원시 총계 기준 마지막 페이지
+    } else if (pageRows.length === 0) {
+      break   // 총계 파싱 실패 시 보수적 종료 (무한루프 방지)
+    }
     page++
   }
 

--- a/src/tools/article-detail.ts
+++ b/src/tools/article-detail.ts
@@ -6,7 +6,7 @@ import { z } from "zod"
 import type { LawApiClient } from "../lib/api-client.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { buildJO } from "../lib/law-parser.js"
-import { cleanHtml } from "../lib/article-parser.js"
+import { cleanHtml, flattenContent } from "../lib/article-parser.js"
 import { formatToolError } from "../lib/errors.js"
 import { toArray } from "../lib/xml-parser.js"
 
@@ -97,10 +97,13 @@ export async function getArticleDetail(
       if (joTitle) resultText += ` ${joTitle}`
       resultText += `\n`
 
-      // 조문내용
+      // 조문내용 — JSON API는 문자열 또는 (중첩)배열로 반환한다.
+      // String(배열)은 콤마로 뭉개지고 중첩 항목은 [object Object]가 되어
+      // 같은 조문을 get_law_text와 다르게(훼손된 채) 출력하던 결함.
+      // 형제 도구들처럼 flattenContent로 평탄화한다.
       if (unit.조문내용) {
-        const content = typeof unit.조문내용 === "string" ? unit.조문내용 : String(unit.조문내용)
-        resultText += `${cleanHtml(content)}\n`
+        const content = flattenContent(unit.조문내용)
+        if (content) resultText += `${cleanHtml(content)}\n`
       }
 
       // 항 내용

--- a/src/tools/historical-law.test.ts
+++ b/src/tools/historical-law.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest"
+import { getHistoricalLaw } from "./historical-law.js"
+import type { LawApiClient } from "../lib/api-client.js"
+
+// 실제 eflaw JSON 축약 — 법령명은 "법령명_한글" 키, 소관부처는 {content} 객체로 온다
+// (라이브 스모크에서 "법령명: N/A" + "소관부처: [object Object]" 노출로 발견된 실형상)
+const HIST_JSON = JSON.stringify({
+  법령: {
+    기본정보: {
+      법령명_한글: "상법",
+      시행일자: "20260910",
+      공포일자: "20250909",
+      공포번호: "21044",
+      제개정구분명: "일부개정",
+      소관부처: { content: "법무부", 소관부처코드: "1270000" },
+    },
+    조문: [
+      { 조문번호: "1", 조문제목: "목적", 조문내용: ["제1조(목적)", "이 법은 상사에 관하여…"] },
+    ],
+  },
+})
+
+describe("getHistoricalLaw — JSON 객체 필드 안전 문자열화", () => {
+  it("소관부처 객체·법령명_한글 키·조문내용 배열을 훼손 없이 출력", async () => {
+    const client = {
+      fetchApi: async () => HIST_JSON,
+    } as unknown as LawApiClient
+
+    const r = await getHistoricalLaw(client, { mst: "273629" })
+    const t = r.content[0].text
+    expect(t).toContain("법령명: 상법")          // 종전엔 N/A
+    expect(t).toContain("소관부처: 법무부")       // 종전엔 [object Object]
+    expect(t).toContain("이 법은 상사에")          // 배열 조문내용 평탄화
+    expect(t).not.toContain("[object Object]")
+  })
+})

--- a/src/tools/historical-law.ts
+++ b/src/tools/historical-law.ts
@@ -2,6 +2,20 @@ import { z } from "zod";
 import type { LawApiClient } from "../lib/api-client.js";
 import { truncateResponse, formatDateDot } from "../lib/schemas.js";
 import { formatToolError } from "../lib/errors.js";
+import { cleanHtml, flattenContent } from "../lib/article-parser.js";
+
+/** JSON 필드 안전 문자열화 — 객체/배열이 와도 "[object Object]"를 만들지 않는다 */
+function safeText(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (v == null) return "";
+  if (Array.isArray(v)) return flattenContent(v);
+  if (typeof v === "object") {
+    // 법제처 JSON은 {content: "..."} 꼴 래핑이 흔함 (소관부처 등)
+    const c = (v as Record<string, unknown>).content;
+    return typeof c === "string" ? c : flattenContent(v as never) || "";
+  }
+  return String(v);
+}
 
 /**
  * 법령 연혁 조회 도구
@@ -127,15 +141,18 @@ export async function getHistoricalLaw(
     const law = data.법령;
     const basic = law.기본정보 || law;
 
-    let output = `=== ${basic.법령명한글 || basic.법령명 || "연혁법령"} ===\n\n`;
+    // eflaw JSON은 법령명을 "법령명_한글" 키로 주는 경우가 있고(article-detail과 동일),
+    // 소관부처는 {content: "..."} 객체로 온다 — 그대로 보간하면 "[object Object]"가 노출됐다.
+    const lawTitle = safeText(basic.법령명_한글 || basic.법령명한글 || basic.법령명) || "연혁법령";
+    let output = `=== ${lawTitle} ===\n\n`;
 
     output += `기본 정보:\n`;
-    output += `  법령명: ${basic.법령명한글 || basic.법령명 || "N/A"}\n`;
-    output += `  시행일자: ${basic.시행일자 || "N/A"}\n`;
-    output += `  공포일자: ${basic.공포일자 || "N/A"}\n`;
-    output += `  공포번호: ${basic.공포번호 || "N/A"}\n`;
-    output += `  제개정구분: ${basic.제개정구분명 || basic.제개정구분 || "N/A"}\n`;
-    output += `  소관부처: ${basic.소관부처명 || basic.소관부처 || "N/A"}\n\n`;
+    output += `  법령명: ${lawTitle}\n`;
+    output += `  시행일자: ${safeText(basic.시행일자) || "N/A"}\n`;
+    output += `  공포일자: ${safeText(basic.공포일자) || "N/A"}\n`;
+    output += `  공포번호: ${safeText(basic.공포번호) || "N/A"}\n`;
+    output += `  제개정구분: ${safeText(basic.제개정구분명 || basic.제개정구분) || "N/A"}\n`;
+    output += `  소관부처: ${safeText(basic.소관부처명 || basic.소관부처) || "N/A"}\n\n`;
 
     // Extract articles
     const rawArticles = law.조문;
@@ -151,8 +168,8 @@ export async function getHistoricalLaw(
 
         if (article) {
           output += `${args.jo}:\n`;
-          if (article.조문제목) output += `제목: ${article.조문제목}\n`;
-          output += `${article.조문내용 || "내용 없음"}\n`;
+          if (article.조문제목) output += `제목: ${safeText(article.조문제목)}\n`;
+          output += `${cleanHtml(safeText(article.조문내용)) || "내용 없음"}\n`;
         } else {
           output += `[NOT_FOUND] ${args.jo}를 찾을 수 없습니다.\n⚠️ LLM은 조문을 추측/생성하지 마세요.\n`;
           output += `\n조문 목록:\n`;
@@ -164,9 +181,9 @@ export async function getHistoricalLaw(
         // Show all articles (limited)
         output += `조문 (총 ${articles.length}개):\n\n`;
         for (const article of articles.slice(0, 30)) {
-          const joNum = article.조문번호 || article.조번호 || "";
-          const title = article.조문제목 || "";
-          const content = article.조문내용 || "";
+          const joNum = safeText(article.조문번호 || article.조번호);
+          const title = safeText(article.조문제목);
+          const content = cleanHtml(safeText(article.조문내용));
 
           output += `제${joNum}조`;
           if (title) output += ` (${title})`;

--- a/src/tools/historical-law.ts
+++ b/src/tools/historical-law.ts
@@ -57,7 +57,13 @@ export async function searchHistoricalLaw(
       };
     }
 
-    let output = `${args.lawName} 연혁 (총 ${histories.length}개 버전):\n\n`;
+    // lsHistory는 서버측 총계를 제공하지 않아 "총 N개"로 단정할 수 없다.
+    // display 상한에 걸린 경우(정확히 상한만큼 조회) 이전 연혁이 더 있을 수 있음을 병기.
+    const displayCap = args.display || 50;
+    const capNote = histories.length >= displayCap
+      ? ` — display 상한(${displayCap}) 도달, 조회 범위 밖 연혁이 더 있을 수 있음`
+      : "";
+    let output = `${args.lawName} 연혁 (조회된 ${histories.length}개 버전${capNote}):\n\n`;
 
     for (const h of histories) {
       const efDate = formatDateDot(h.efYd);

--- a/src/tools/scenarios/time-travel.test.ts
+++ b/src/tools/scenarios/time-travel.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest"
+import { pickVersion } from "./time-travel.js"
+
+const v = (mst: string, efYd: string) => ({ mst, efYd, lawNm: "테스트법", ancNo: "1", ancYd: "", rrCls: "일부개정" })
+
+describe("pickVersion — 시행일 빈 값 NaN 오염", () => {
+  // 회귀: 필터는 efYd=""를 0으로 폴백해 통과시키는데 정렬은 parseInt("")=NaN을
+  // 그대로 써서 비교자가 NaN을 반환 — 정렬이 비결정적이 되어 "해당 시점 시행 버전"이
+  // 아닌 버전이 뽑힐 수 있었다.
+  it("빈 efYd가 섞여도 기준일 이하 최대 시행일 버전을 뽑는다", () => {
+    const versions = [v("A", "20200101"), v("B", ""), v("C", "20230101"), v("D", "20220601")]
+    expect(pickVersion(versions, "20240101")?.mst).toBe("C")
+  })
+
+  it("빈 efYd만 있으면 그것이라도 반환 (기존 동작 유지)", () => {
+    expect(pickVersion([v("B", "")], "20240101")?.mst).toBe("B")
+  })
+
+  it("기준일 이전 버전이 없으면 undefined", () => {
+    expect(pickVersion([v("C", "20230101")], "20200101")).toBeUndefined()
+  })
+})

--- a/src/tools/scenarios/time-travel.ts
+++ b/src/tools/scenarios/time-travel.ts
@@ -102,7 +102,7 @@ function diffArticles(
 }
 
 /** efYd <= targetDate 중 가장 큰 (해당 시점 시행 버전) */
-function pickVersion(versions: HistoricalVersion[], targetDate: string): HistoricalVersion | undefined {
+export function pickVersion(versions: HistoricalVersion[], targetDate: string): HistoricalVersion | undefined {
   const target = parseInt(targetDate, 10)
   if (isNaN(target)) return undefined
   const eligible = versions.filter(v => {
@@ -110,7 +110,10 @@ function pickVersion(versions: HistoricalVersion[], targetDate: string): Histori
     return !isNaN(ef) && ef <= target
   })
   if (eligible.length === 0) return undefined
-  eligible.sort((a, b) => parseInt(b.efYd, 10) - parseInt(a.efYd, 10))
+  // 필터는 빈 efYd를 0으로 취급해 통과시키므로 정렬도 같은 폴백을 써야 한다.
+  // parseInt("")는 NaN → 비교자가 NaN을 반환하면 정렬 순서가 비결정적이 되어
+  // "해당 시점 시행 버전"이 아닌 엉뚱한 버전이 뽑힐 수 있다.
+  eligible.sort((a, b) => parseInt(b.efYd || "0", 10) - parseInt(a.efYd || "0", 10))
   return eligible[0]
 }
 


### PR DESCRIPTION
## 증상 4건

1. **연혁 수집이 1페이지에서 조기 종료** — 본법+시행령·규칙 연혁 합계가 500행을 넘는 법령(소득세법류)에서 옛 본법 버전이 통째로 누락 → `applicable_law`가 기준일 버전을 최신 쪽으로 오특정
2. `time_travel`의 버전 선택 정렬이 빈 시행일에서 NaN 비교자가 되어 비결정적
3. `get_historical_law`가 `소관부처: [object Object]`·`법령명: N/A`를 출력 (JSON 객체 필드를 그대로 문자열 보간)
4. 항 번호 원숫자 매핑이 ①~⑳뿐이라 ㉑ 이상(별도 유니코드 블록)이 NaN → `verify_citations`가 **실존하는 제21항+ 인용을 "존재하지 않는 항"으로 오판**

## 원인·수정

- 페이징 종료 판정이 "필터 후 행수 < pageSize"였음 — 원시 500행이 대상 법령 몇 행으로 필터링되면 즉시 종료. **원시 총계(totalCount) 기준**으로 변경
- 정렬 비교자에 빈 시행일 폴백(`|| "0"`) 추가 (필터와 동일 규칙)
- eflaw JSON의 `{content}` 객체·`법령명_한글` 키·배열 조문내용을 안전 평탄화(`safeText`)
- 원숫자 매핑 ㉑~㊿ 확장

## 검증

- 실제 lsHistory HTML 행 형식·eflaw JSON 실응답 기반 픽스처 회귀 테스트 8건 (페이징 테스트는 2페이지 수집 강제)
- 행위시법 검증셋에서 4페이지(1,696행) 연혁 법령 정특정 확인
- `typecheck`·`test`·`build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)