### PR TITLE
fix(verify_citations): 폐지된 법령 인용을 '환각'으로 오탐하지 않도록 연혁 폴백 추가

### DIFF
--- a/src/lib/law-search.repealed.test.ts
+++ b/src/lib/law-search.repealed.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import { parseLawXml, pickRepealed, type LawInfo } from "./law-search.js"
+
+// eflaw 검색 XML 조각 — 실제 응답 구조(현행연혁코드·시행일자 포함)
+const EFLAW_XML = `
+<LawSearch>
+  <law>
+    <법령일련번호>235583</법령일련번호>
+    <현행연혁코드>연혁</현행연혁코드>
+    <법령명한글>저탄소 녹색성장 기본법</법령명한글>
+    <법령ID>011134</법령ID>
+    <법령구분명>법률</법령구분명>
+    <시행일자>20220325</시행일자>
+  </law>
+  <law>
+    <법령일련번호>200000</법령일련번호>
+    <현행연혁코드>연혁</현행연혁코드>
+    <법령명한글>저탄소 녹색성장 기본법</법령명한글>
+    <법령ID>011134</법령ID>
+    <법령구분명>법률</법령구분명>
+    <시행일자>20200527</시행일자>
+  </law>
+</LawSearch>`
+
+describe("parseLawXml — 현행연혁 상태·시행일 캡처", () => {
+  it("현행연혁코드와 시행일자를 함께 파싱한다", () => {
+    const rows = parseLawXml(EFLAW_XML, 10)
+    expect(rows).toHaveLength(2)
+    expect(rows[0].lawName).toBe("저탄소 녹색성장 기본법")
+    expect(rows[0].status).toBe("연혁")
+    expect(rows[0].effectiveDate).toBe("20220325")
+  })
+})
+
+describe("pickRepealed — 폐지(연혁) 법령 최신본 선택", () => {
+  it("질의명과 일치하는 연혁 법령 중 최신 시행본을 고른다", () => {
+    const rows = parseLawXml(EFLAW_XML, 10)
+    const r = pickRepealed(rows, "저탄소 녹색성장 기본법")
+    expect(r?.lawName).toBe("저탄소 녹색성장 기본법")
+    expect(r?.effectiveDate).toBe("20220325") // 20200527보다 최신
+  })
+
+  it("공백 차이는 무시하고 매칭한다", () => {
+    const rows = parseLawXml(EFLAW_XML, 10)
+    expect(pickRepealed(rows, "저탄소녹색성장기본법")?.status).toBe("연혁")
+  })
+
+  it("현행(연혁 아님) 행은 폐지로 잡지 않는다", () => {
+    const current: LawInfo[] = [
+      { lawName: "민법", lawId: "1", mst: "1", lawType: "법률", status: "현행", effectiveDate: "20230101" },
+    ]
+    expect(pickRepealed(current, "민법")).toBeUndefined()
+  })
+
+  it("이름이 다른 연혁 법령은 흡수하지 않는다", () => {
+    const rows = parseLawXml(EFLAW_XML, 10)
+    expect(pickRepealed(rows, "전혀 다른 법률")).toBeUndefined()
+  })
+})

--- a/src/lib/law-search.ts
+++ b/src/lib/law-search.ts
@@ -15,6 +15,8 @@ export interface LawInfo {
   lawId: string
   mst: string
   lawType: string
+  status?: string        // 현행연혁코드: "현행" | "연혁"(폐지·과거본). eflaw 검색 시에만 채워짐
+  effectiveDate?: string // 시행일자 (YYYYMMDD)
 }
 
 /** 법령명이 아닌 부가 키워드 제거 (법제처 lawSearch API는 법령명 검색이므로) */
@@ -38,6 +40,8 @@ export function parseLawXml(xmlText: string, max: number): LawInfo[] {
       lawId: extractTag(content, "법령ID"),
       mst: extractTag(content, "법령일련번호"),
       lawType: extractTag(content, "법령구분명"),
+      status: extractTag(content, "현행연혁코드") || undefined,
+      effectiveDate: extractTag(content, "시행일자") || undefined,
     })
   }
   return results
@@ -138,4 +142,38 @@ export async function findLaws(
   }
 
   return final
+}
+
+/**
+ * eflaw 검색 결과(연혁 포함)에서 질의명과 일치하는 '폐지(연혁)' 법령의 최신본을 고른다.
+ *
+ * 순수 함수(테스트 용이) — findRepealedLaw가 네트워크 후 이 로직으로 판정.
+ * 현행(target=law)에서 못 찾은 인용이 '지어낸 법령'인지 '폐지된 법령'인지 가른다.
+ * 매칭은 공백무시 완전일치 또는 접두(약칭)만 허용해 엉뚱한 법령 흡수를 막는다.
+ */
+export function pickRepealed(rows: LawInfo[], query: string): LawInfo | undefined {
+  const norm = (s: string) => s.replace(/\s+/g, "")
+  const q = norm(query)
+  return rows
+    .filter((r) => r.status === "연혁"
+      && (norm(r.lawName) === q || norm(r.lawName).startsWith(q)))
+    .sort((a, b) => (b.effectiveDate || "").localeCompare(a.effectiveDate || ""))[0]
+}
+
+/**
+ * 폐지(연혁) 법령 조회 — target=eflaw로 과거·폐지본을 검색해 최신 연혁본을 반환.
+ * 현행 검색이 0건일 때만 보조로 호출(환각 vs 폐지 구분용). 실패 시 undefined.
+ */
+export async function findRepealedLaw(
+  apiClient: LawApiClient,
+  query: string,
+  apiKey?: string
+): Promise<LawInfo | undefined> {
+  let xmlText: string
+  try {
+    xmlText = await apiClient.searchLaw(query, apiKey, 30, "eflaw")
+  } catch {
+    return undefined  // eflaw 조회 실패는 조용히 폴백(기존 NOT_FOUND 경로 유지)
+  }
+  return pickRepealed(parseLawXml(xmlText, 100), query)
 }

--- a/src/tools/verify-citations.ts
+++ b/src/tools/verify-citations.ts
@@ -18,7 +18,7 @@
 import { z } from "zod"
 import type { LawApiClient } from "../lib/api-client.js"
 import { buildJO } from "../lib/law-parser.js"
-import { findLaws, type LawInfo } from "../lib/law-search.js"
+import { findLaws, findRepealedLaw, type LawInfo } from "../lib/law-search.js"
 import { parseHangNumber } from "../lib/article-parser.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { formatToolError } from "../lib/errors.js"
@@ -145,6 +145,12 @@ function parseCitations(text: string, maxCitations: number): ParsedCitation[] {
   return citations
 }
 
+// "20220325" → "2022-03-25". 형식 이상이면 원본 그대로.
+function formatYmd(ymd?: string): string {
+  if (!ymd || !/^\d{8}$/.test(ymd)) return ymd || ""
+  return `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}`
+}
+
 function formatCitationLabel(c: ParsedCitation, officialName?: string): string {
   const name = officialName || c.lawName || "(법령명 미지정)"
   let label = `${name} ${c.displayArticle}`
@@ -180,6 +186,15 @@ async function verifyOne(
       }
     }
     if (!fallback) {
+      // 현행(target=law)에 없음 → 폐지된 법령인지 연혁(eflaw)에서 확인.
+      // '지어낸 인용(환각)'과 '실존했으나 폐지된 법령'을 구분(존재≠생존).
+      for (const cand of lawNameCandidates(cite.lawName)) {
+        const repealed = await findRepealedLaw(apiClient, cand, apiKey)
+        if (repealed) {
+          const d = formatYmd(repealed.effectiveDate)
+          return `⌛ ${formatCitationLabel(cite, repealed.lawName)} — [REPEALED] 「${repealed.lawName}」은(는) 폐지된 법령입니다(연혁${d ? `, 최종시행 ${d}` : ""}). 실존했으나 현행 법령이 아님 — 후속·대체 법령 확인 필요`
+        }
+      }
       return `✗ ${inputLabel} — [NOT_FOUND] 법제처 DB에 해당 법령 없음 (법령명 오탈자 또는 존재하지 않는 법령)`
     }
     if (!chosen) {
@@ -277,16 +292,22 @@ export async function verifyCitations(
     const okCount = results.filter((r) => r.startsWith("✓")).length
     const failCount = results.filter((r) => r.startsWith("✗")).length
     const warnCount = results.filter((r) => r.startsWith("⚠")).length
+    const repealedCount = results.filter((r) => r.startsWith("⌛")).length
 
-    // 환각 감지 시 isError=true로 LLM이 "검증 통과"로 오인하지 못하게 차단
+    // 환각 감지 시 isError=true로 LLM이 "검증 통과"로 오인하지 못하게 차단.
+    // 폐지 법령(⌛)은 실존했으므로 환각이 아님 — failCount에 포함되지 않는다.
     const hasHallucination = failCount > 0
 
     const headerMarker = hasHallucination
       ? "[HALLUCINATION_DETECTED] "
-      : warnCount > 0 ? "[PARTIAL_VERIFIED] " : "[VERIFIED] "
-    let output = `${headerMarker}== 인용 검증 결과 ==\n총 ${citations.length}건 | ✓ ${okCount} 실존 | ✗ ${failCount} 오류 | ⚠ ${warnCount} 확인필요\n\n`
+      : repealedCount > 0 ? "[REPEALED_REFERENCE] "
+        : warnCount > 0 ? "[PARTIAL_VERIFIED] " : "[VERIFIED] "
+    let output = `${headerMarker}== 인용 검증 결과 ==\n총 ${citations.length}건 | ✓ ${okCount} 실존 | ✗ ${failCount} 오류 | ⌛ ${repealedCount} 폐지 | ⚠ ${warnCount} 확인필요\n\n`
     for (const line of results) {
       output += `${line}\n`
+    }
+    if (repealedCount > 0) {
+      output += `\n⌛ [REPEALED_REFERENCE] ${repealedCount}건은 폐지된 법령(연혁) 인용입니다. 실존했던 법령이라 '환각'은 아니지만 현행이 아니므로, 후속·대체 법령으로 갱신이 필요한지 확인하세요.\n`
     }
     if (hasHallucination) {
       output += `\n⚠️ [HALLUCINATION_DETECTED] ${failCount}건 인용이 법제처 DB에 실존하지 않거나 인용 내용(조문 제목)이 실제와 불일치합니다.\n`


### PR DESCRIPTION
## Problem

`verify_citations`가 현행 검색(`target=law`)만 사용 → **폐지 법령 인용을 환각으로 오탐**.
검색 0건 → `✗ [NOT_FOUND]` → `[HALLUCINATION_DETECTED]` (`isError: true`). 실존했던 법을 "지어낸 인용"으로 낙인.

```
in : "국유재산관리특별회계법 제6조"   # 2007 폐지, 실존
now: ✗ [NOT_FOUND] 존재하지 않는 법령 → [HALLUCINATION_DETECTED]   # 오탐
```

## Fix

`findLaws` 0건일 때 `target=eflaw` 1회 폴백 → `현행연혁코드="연혁"`이면 폐지 법령으로 분리 보고.

```
fix: ⌛ [REPEALED] 폐지된 법령(연혁, 최종시행 2007-01-01) → [REPEALED_REFERENCE]   # isError: false
```

- `lib/law-search.ts` — `LawInfo.status`/`.effectiveDate` 추가, `parseLawXml` 캡처, `pickRepealed()`(순수)·`findRepealedLaw()`(eflaw) 신설
- `tools/verify-citations.ts` — NOT_FOUND 직전 폴백, `⌛` 마커 + `[REPEALED_REFERENCE]` 요약. 폐지 건은 `failCount` 미포함 → `isError` 불변
- `lib/law-search.repealed.test.ts` — 파싱/선택 순수함수 테스트 5건

## Notes

- 추가 호출은 현행 0건일 때만 (정상 인용 비용 0)
- 폐지 법령은 조문 단위 미검증, 법령 단위 폐지만 표시
- 정상(`✓`)·환각(`✗`, e.g. 형법 제9999조) 판정 불변 — 폐지만 `✗`→`⌛`
- `tsc --noEmit` OK · 67/67 pass
