### PR TITLE
fix: 「」 표기·가운뎃점(·/ㆍ) 차이로 verify_citations 환각탐지가 미가동되던 문제

### DIFF
--- a/src/lib/law-search.test.ts
+++ b/src/lib/law-search.test.ts
@@ -70,4 +70,22 @@ describe("looseMatchLawName (lib 승격 후 동작 유지)", () => {
     expect(looseMatchLawName("자본시장과 금융투자업에 관한 법률", "자본시장과금융투자업에관한법률")).toBe(true)
     expect(looseMatchLawName("상법", "보상법")).toBe(false)
   })
+
+  // 회귀: 법제처 공식 법령명은 한글 가운뎃점 'ㆍ'(U+318D)인데 실무 문서·LLM 텍스트는
+  // 라틴 중점 '·'(U+00B7)를 쓴다. 표기 차이만으로 불일치가 되면 verify_citations는
+  // ⚠ 부분매칭에 머물러 조문 검증에 진입하지 못하고 환각 탐지가 미가동된다.
+  it("가운뎃점 표기 차이를 흡수한다 (·/ㆍ/‧/•/・)", () => {
+    expect(looseMatchLawName("식품 등의 표시·광고에 관한 법률", "식품 등의 표시ㆍ광고에 관한 법률")).toBe(true)
+    expect(looseMatchLawName("식품ㆍ의약품분야 시험ㆍ검사 등에 관한 법률", "식품·의약품분야 시험·검사 등에 관한 법률")).toBe(true)
+    expect(looseMatchLawName("agri·food", "agri‧food")).toBe(true)
+  })
+
+  it("가운뎃점 정규화가 무관 법령을 통과시키지는 않는다", () => {
+    expect(looseMatchLawName("민법", "난민법")).toBe(false)
+    expect(looseMatchLawName("식품·의약품분야 시험·검사 등에 관한 법률", "식품위생법")).toBe(false)
+  })
+
+  it("가운뎃점 포함 법령명도 resolvedLawMatches 가드를 통과한다", () => {
+    expect(resolvedLawMatches("식품 등의 표시·광고에 관한 법률", "식품 등의 표시ㆍ광고에 관한 법률")).toBe(true)
+  })
 })

--- a/src/lib/law-search.ts
+++ b/src/lib/law-search.ts
@@ -20,11 +20,18 @@ export interface LawInfo {
   effectiveDate?: string // 시행일자 (YYYYMMDD)
 }
 
-// 후보 법령명과 법제처 공식 법령명의 느슨한 일치 — 공백 무시 + 접두/약칭 허용.
+// 법령명 구분점(가운뎃점) 표기 흔들림. 법제처 공식 법령명은 **한글 가운뎃점 'ㆍ'(U+318D)**
+// 를 쓰지만("식품 등의 표시ㆍ광고에 관한 법률"), 실무 문서·판결문·LLM 출력은 라틴 중점
+// '·'(U+00B7)를 쓰는 것이 보통이고 '‧'(U+2027)·'•'(U+2022)·'・'(U+30FB)도 섞인다.
+// 표기만 다른 같은 법을 불일치로 판정하면 verify_citations는 조문 검증에 진입조차 못 하고
+// (⚠ 부분매칭), applicable_law·impact_map은 resolvedLawMatches 가드에서 NOT_FOUND가 된다.
+const INTERPUNCT_RE = /[·ㆍ‧•・]/g
+
+// 후보 법령명과 법제처 공식 법령명의 느슨한 일치 — 공백·가운뎃점 무시 + 접두/약칭 허용.
 // findLaws가 관련도 정렬은 해도 매칭이 전혀 다른 법령일 수 있어 최종 방어선으로 사용.
 // (verify-citations에서 쓰던 것을 lib로 승격 — applicable_law/impact_map 가드 공용)
 export function looseMatchLawName(target: string, official: string): boolean {
-  const normalize = (s: string) => s.replace(/\s+/g, "")
+  const normalize = (s: string) => s.replace(/\s+/g, "").replace(INTERPUNCT_RE, "")
   const targetNorm = normalize(target)
   const officialNorm = normalize(official)
   return officialNorm === targetNorm

--- a/src/tools/verify-citations.test.ts
+++ b/src/tools/verify-citations.test.ts
@@ -1,5 +1,32 @@
 import { describe, it, expect } from "vitest"
-import { lawNameCandidates, looseMatchLawName } from "./verify-citations.js"
+import { lawNameCandidates, looseMatchLawName, extractLawName } from "./verify-citations.js"
+
+describe("extractLawName — 인용 직전 문맥에서 법령명 추출", () => {
+  // 회귀: 「법령명」 제N조 는 법제처·판결문·실무 문서의 표준 표기인데, 닫는 낫표가
+  // LAW_NAME_REGEX의 $ 앵커를 막아 법령명이 전혀 추출되지 않았다. 그 결과 조문 실존
+  // 검증에 진입하지 못해 없는 조문·없는 항조차 ✗로 잡히지 않았다(환각 탐지 미가동).
+  it("낫표로 감싼 표준 표기에서 법령명을 추출한다", () => {
+    expect(extractLawName("「식품 등의 표시·광고에 관한 법률」 ")).toBe("식품 등의 표시·광고에 관한 법률")
+    expect(extractLawName("이 사건에는 「형법」")).toBe("형법")
+    expect(extractLawName("『민법』")).toBe("민법")
+  })
+
+  it("낫표 없는 평문은 종전대로 추출 (#55 동작 유지)", () => {
+    expect(extractLawName("절도죄는 형법")).toBe("절도죄는 형법")
+    expect(extractLawName("전자상거래 등에서의 소비자보호에 관한 법률")).toBe(
+      "전자상거래 등에서의 소비자보호에 관한 법률"
+    )
+  })
+
+  it("접속사·부사 수식어는 제거", () => {
+    expect(extractLawName("또한 상법")).toBe("상법")
+  })
+
+  it("법령명이 없으면 undefined", () => {
+    expect(extractLawName("계약서에 따라")).toBeUndefined()
+    expect(extractLawName("")).toBeUndefined()
+  })
+})
 
 describe("lawNameCandidates", () => {
   it("법령명 직전 캡처(수식어 없음)는 후보 1개", () => {

--- a/src/tools/verify-citations.ts
+++ b/src/tools/verify-citations.ts
@@ -72,6 +72,19 @@ export function lawNameCandidates(lawName: string): string[] {
 // 기존 import 경로 호환을 위해 재수출.
 export { looseMatchLawName }
 
+// 인용 직전 문맥에서 법령명을 추출.
+// 「법령명」 제8조 는 법제처·판결문·실무 문서의 표준 인용 표기인데, 닫는 낫표가
+// LAW_NAME_REGEX의 $ 앵커를 막아 법령명이 **전혀** 추출되지 않았다(→ "법령명 추출 실패").
+// 이 경우 조문 실존 검증에 진입하지 못해 없는 조문·없는 항도 ✗로 잡히지 않는다.
+// = 환각 탐지가 조용히 미가동. 따라서 닫는 인용기호를 먼저 벗긴다.
+export function extractLawName(lookbackRaw: string): string | undefined {
+  const lookback = lookbackRaw.replace(/[\s」』】〕>]+$/, "")
+  const m = lookback.match(LAW_NAME_REGEX)
+  if (!m) return undefined
+  const name = m[1].replace(/\s+/g, " ").trim().replace(LAW_NAME_STOPWORDS, "").trim()
+  return name.length >= 2 ? name : undefined
+}
+
 // 인용 바로 뒤 "(제목)"에서 조문 제목 claim 추출 — 내용검증용.
 // 개정이력·날짜·항호 참조 괄호는 조문 제목이 아니므로 제외.
 function extractClaimTitle(after: string): string | undefined {
@@ -97,12 +110,7 @@ function parseCitations(text: string, maxCitations: number): ParsedCitation[] {
 
     // 직전 30자에서 법령명 역추적
     const lookbackStart = Math.max(0, m.index - 30)
-    const lookback = text.slice(lookbackStart, m.index).replace(/\s+$/, "")
-    const lawMatch = lookback.match(LAW_NAME_REGEX)
-    let lawName: string | undefined = lawMatch
-      ? lawMatch[1].replace(/\s+/g, " ").trim().replace(LAW_NAME_STOPWORDS, "").trim()
-      : undefined
-    if (lawName && lawName.length < 2) lawName = undefined
+    const lawName = extractLawName(text.slice(lookbackStart, m.index))
 
     const jo = parseInt(joStr, 10)
     const joBranch = branchStr ? parseInt(branchStr, 10) : undefined


### PR DESCRIPTION
## 요약

법령명 표기 정규화 2건입니다. 두 건 모두 **검증이 실패하는** 문제가 아니라 **검증이 조용히 수행되지 않는데 출력은 경고(⚠)로만 보이는** 문제라서, 인용이 실제로 틀렸을 때도 `✗`가 나오지 않습니다. `verify_citations`를 환각 게이트로 파이프라인에 넣어 쓰는 경우 "통과"로 오독될 수 있어 올립니다.

## 1. `「법령명」 제N조` 에서 법령명 추출 실패 (`src/tools/verify-citations.ts`)

`LAW_NAME_REGEX`는 `$` 앵커로 법령명 종단(`…법`/`법률`/`시행령`…)을 찾는데, 표준 인용 표기의 **닫는 낫표가 lookback 끝에 남아** 앵커가 걸리지 않았습니다. 기존 코드는 후행 공백만 제거(`/\s+$/`)합니다.

```
「식품 등의 표시·광고에 관한 법률」 제8조제1항 제5호
→ ⚠ (법령명 미지정) 제8조 제1항 제5호 — 법령명 추출 실패
```

법령명이 없으면 조문 실존 검증 자체에 진입하지 못하므로, **같은 텍스트에 없는 조문·없는 항이 있어도 탐지되지 않습니다.**

닫는 인용기호(`」』】〕>`)를 함께 벗기고, 해당 로직을 `extractLawName`으로 분리해 테스트 가능하게 했습니다. 낫표 없는 평문 경로(#55 수식어 순차 축약)는 동작 불변입니다.

## 2. 가운뎃점 표기 차이로 공식 법령명과 불일치 (`src/lib/law-search.ts`)

법제처 공식 법령명은 **한글 가운뎃점 `ㆍ`(U+318D)** 를 씁니다 — `식품 등의 표시ㆍ광고에 관한 법률`. 반면 실무 문서·판결문·LLM 출력은 **라틴 중점 `·`(U+00B7)** 가 보통이고 `‧`(U+2027)·`•`·`・`도 섞입니다. `looseMatchLawName`의 정규화가 공백만 제거하기 때문에 표기만 다른 같은 법이 불일치로 떨어집니다.

```
verify_citations : ⚠ … — 법제처 검색은 '식품 등의 표시ㆍ광고에 관한 법률'(으)로만 매칭됨
applicable_law   : [NOT_FOUND] '식품 등의 표시·광고에 관한 법률' 법령을 정확히 찾지 못했습니다.
                   검색 최상위는 '식품 등의 표시ㆍ광고에 관한 법률'이지만 …
```

후자는 v4.8.0 #66 가드가 의도대로 동작한 결과라 안전한 실패이긴 하나, 표기 차이만으로 정상 조회가 막힙니다. `normalize`에 가운뎃점 제거를 추가했습니다. 무관 법령 차단(`민법`→`난민법`, `상법`→`보상법`)은 그대로 유지됩니다.

참고로 같은 정규화가 `src/lib/citation-content-matcher.ts:62`에는 이미 있습니다(`.replace(/[·•]/g, ' ')`) — 법령명 쪽에만 빠져 있었습니다.

## 결합 효과

두 정규화를 모두 적용하면 같은 텍스트가 이렇게 바뀝니다.

| 입력 | before | after |
|---|---|---|
| `「식품 등의 표시·광고에 관한 법률」 제8조제1항` | ⚠ 법령명 추출 실패 | ✓ 실존 (조문제목 병기) |
| 위 텍스트의 `제999조` | 탐지 안 됨 | ✗ NOT_FOUND (존재 범위 병기) |
| 위 텍스트의 `제8조 제99항` | 탐지 안 됨 | ✗ NOT_FOUND (최대 항 병기) |

## 검증

- 회귀 테스트 **7건 추가** — `extractLawName` 4건(낫표 표기·평문 경로 유지·수식어 제거·법령명 부재), `looseMatchLawName` 3건(가운뎃점 5종 흡수·무관 법령 차단 유지·`resolvedLawMatches` 경유).
- **전체 113 passed** (기존 106 + 7), `tsc --noEmit` 클린.
- 관측은 `mcp.gomdori.app/law` 호스팅 인스턴스에 식품표시광고 도메인 인용을 넣어 확인했습니다. **로컬에 OC 키가 없어 라이브 통합 테스트는 미수행** — 이 PR의 검증은 단위 테스트 범위입니다.

## 손대지 않은 것

고시·행정규칙 인용(`식품등의 표시기준 제2조`, `식품의 기준 및 규격`)은 `LAW_NAME_REGEX`의 접미사 목록(`법률|법|시행령|시행규칙|규칙|규정|조례`) 밖이라 여전히 추출되지 않습니다. 이건 `findLaws`(target=law)가 아니라 `admrul` 조회 경로가 필요해 별건으로 판단했고, 잘못 붙이면 실존하는 고시가 `✗`로 낙인될 위험이 있어 이 PR 범위에서 제외했습니다.
