### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/korean-law-mcp.svg)](https://www.npmjs.com/package/korean-law-mcp)
 [![MCP 1.27](https://img.shields.io/badge/MCP-1.27-blue)](https://modelcontextprotocol.io)
+[![MCP status](https://mcpvitals.com/badge/e8c6790f9c.svg)](https://mcpvitals.com/status/e8c6790f9c)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 <a href="https://jocohunt.com/p/5lkkxp3x" target="_blank" rel="noopener" title="조코헌트 주간 1등 Top 1 위너">


### PR DESCRIPTION
Hi 👋

I run [MCP Vitals](https://mcpvitals.com), a health monitor for MCP servers. I set up a free public monitor for your hosted server (`korean-law-mcp.fly.dev`) — it runs the real `initialize → tools/list` handshake every few minutes and currently sees it healthy with 10 tools.

This PR adds a small live status badge to the README so users can see at a glance that the server is up — and it surfaces downtime or tool-schema drift if that ever changes:

[![MCP status](https://mcpvitals.com/badge/e8c6790f9c.svg)](https://mcpvitals.com/status/e8c6790f9c)

- Free, nothing to sign up for; the badge links to a public uptime/latency page.
- Another MCP maintainer ([heymrun/heym](https://github.com/heymrun/heym/pull/430)) just merged the same badge, for reference.
- Not interested? Just close this — no worries at all. 감사합니다 🙏
