### PR TITLE
security: harden request and release boundaries

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,7 +21,7 @@
   "mcpServers": {
     "korean-law": {
       "command": "npx",
-      "args": ["-y", "korean-law-mcp@latest"],
+      "args": ["-y", "--ignore-scripts", "--omit=optional", "korean-law-mcp@latest"],
       "env": {
         "LAW_OC": "${user_config.api_key}"
       }

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -12,7 +12,9 @@
 
 ### 2단계: npm 릴리스
 4. `npm run build`로 빌드 확인 (실패 시 중단)
-5. `npm version patch|minor` → `npm publish` → `git push --follow-tags`
+5. `npm version patch|minor` → `git push --follow-tags` → 해당 태그의 GitHub Release 생성
+   - `.github/workflows/publish.yml`이 npm trusted publishing(OIDC + provenance)으로 게시한다.
+   - 로컬 `npm publish` 또는 장기 npm 토큰을 사용하지 않는다.
 
 ### 3단계: 통합 호스트 반영
 6. `~/workspace/gomdori-mcp/Dockerfile`의 `korean-law-mcp@X.Y.Z` 핀을 새 버전으로 갱신

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        # Do not execute optional transitive native postinstall downloaders in CI.
+        # Dev tooling has platform-specific optional bindings; install them but
+        # never execute transitive lifecycle scripts.
         run: npm ci --ignore-scripts
 
       - name: Build
@@ -40,3 +41,8 @@ jobs:
 
       - name: Verify packed artifact
         run: npm run verify:package
+
+      - name: Verify production graph without optional dependencies
+        run: |
+          npm prune --omit=dev --omit=optional --ignore-scripts
+          npm run verify:annex-runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,37 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22.12.0]
 
     steps:
-      - uses: actions/checkout@v4
+      # v4 (current tag target at time of pinning)
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        # v4 (current tag target at time of pinning)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        # Do not execute optional transitive native postinstall downloaders in CI.
+        run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build
 
       - name: Test
         run: npm test
+
+      - name: Verify packed artifact
+        run: npm run verify:package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Use an npm CLI with trusted-publishing support
+        run: npm install --global --ignore-scripts npm@11.19.0
+
+      - name: Verify release tag matches package version
+        run: node -e 'const version=require("./package.json").version; if (![version, `v${version}`].includes(process.env.GITHUB_REF_NAME)) { throw new Error(`Release tag ${process.env.GITHUB_REF_NAME} does not match package ${version}`) }'
+
+      - name: Install dependencies without transitive install scripts
+        run: npm ci --ignore-scripts
+
+      - name: Validate source and package
+        run: |
+          npm run typecheck
+          npm test
+          npm run build
+          npm run verify:package
+          npm audit --omit=dev
+
+      - name: Verify production graph without optional dependencies
+        run: |
+          npm prune --omit=dev --omit=optional --ignore-scripts
+          npm run verify:annex-runtime
+
+      - name: Publish with npm trusted publishing and provenance
+        run: npm publish --ignore-scripts --access public --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 >
 > 프로덕션은 이 레포가 아니라 **[gomdori-mcp](https://github.com/chrisryugj/gomdori-mcp) 통합 호스트**(fly 앱 `korean-law-mcp` 1대, MCP 5종 동거)가 서빙한다.
 > - 공식 주소: `https://mcp.gomdori.app/law` (구 `korean-law-mcp.fly.dev/mcp`는 하위호환으로 유지)
-> - **반영 절차**: 이 레포 커밋·푸시 → `npm publish` → `~/workspace/gomdori-mcp/Dockerfile`의 `korean-law-mcp@X.Y.Z` 핀 갱신 → `cd ~/workspace/gomdori-mcp && fly deploy -c fly.production.toml`
+> - **반영 절차**: 이 레포 커밋·푸시 → 버전 태그의 GitHub Release 생성(`publish.yml` trusted publishing) → `~/workspace/gomdori-mcp/Dockerfile`의 `korean-law-mcp@X.Y.Z` 핀 갱신 → `cd ~/workspace/gomdori-mcp && fly deploy -c fly.production.toml`
 > - **🚫 이 레포에서 `fly deploy` 직접 실행 절대 금지** — 통합 이미지를 law 단독 이미지로 덮어써 stats·patent·archhub·school까지 전부 죽는다. 자세한 배경: [docs/FLY-COST.md](docs/FLY-COST.md)
 
 Korean Law MCP Server v4.9.1 - 법제처 42개 API → 10개 통합 도구 (내부 98개) + 9개 시나리오 + 자연어 CLI + HTTP stateless + 판례 토큰 74% 감축 + **legal_research (체인 8종 통합, task 파라미터)** + **legal_analysis (인용검증·판례생사·행위시법·영향그래프 통합, mode 파라미터)** + **time_travel (시점 diff)** + **action_plan (이럴 땐 이렇게, 5단계 안내)** + **시행예정 감지 (search_law가 제명변경·미시행 개정 자동 병기)** + **ordinance_radar (조례 정비 레이더 — 근거 상위법 개정 자동 대조, v4.7.0)** + **인용 검증 표기 내성 (낫표·가운뎃점·`같은 법` 조응, v4.9.0)**
@@ -47,7 +47,7 @@ src/
 ## Commands
 
 ```bash
-npm install           # 의존성 설치
+npm ci --ignore-scripts  # 개발 도구 optional binding은 설치하되 lifecycle script는 비활성
 npm run build         # TypeScript 빌드
 npm run watch         # 개발 모드
 LAW_OC=키 node build/index.js  # MCP 서버 실행
@@ -84,15 +84,20 @@ korean-law get_law_text --mst 160001 --jo "제1조"
 ## Environment
 
 - `LAW_OC`: 법제처 API 키 (필수) - https://open.law.go.kr/LSO/openApi/guideResult.do
-- `TRUST_PROXY`: Express trust proxy (기본 `1`, 첫 프록시만 신뢰). 다단 프록시는 숫자 증가, CIDR/IP 리스트도 패스스루. `true`/`all`은 XFF 스푸핑 위험으로 명시적 opt-in 필요
+- `MCP_HTTP_HOST`: HTTP 바인드 주소 (기본 `127.0.0.1`). 외부 바인드는 인증 또는 아래 명시적 override 필요
+- `MCP_ALLOW_UNAUTHENTICATED_REMOTE`: 인증 없는 외부 바인드를 의도적으로 허용할 때만 `1`
+- `TRUST_PROXY`: Express trust proxy (기본 `false`). 프록시 뒤에서만 `1`~`10`의 정확한 hop 수를 명시하며 문자열/CIDR/`true`는 허용하지 않음
 - `CORS_ORIGIN`: CORS 허용 도메인 (기본 `*` — 프로덕션 명시 권장). **명시 설정 시 Origin 검증의 허용 목록으로도 취급**
 - `ALLOWED_ORIGINS`: Origin 허용 목록(쉼표 구분). `Origin` 헤더가 붙은 요청은 이 목록에 없으면 403 — DNS rebinding 방어. 미설정 + `CORS_ORIGIN` 미설정이면 Origin 있는 요청은 전부 차단(비브라우저 클라이언트는 영향 없음)
-- `MCP_AUTH_TOKEN`: 설정 시 `/mcp`에 `x-mcp-token` 또는 `Authorization: Bearer` 인증 요구. **폐쇄망·사내망 배포 필수** (미설정이면 기존처럼 공개 동작)
+- `MCP_AUTH_TOKEN`: 설정 시 `/mcp`에 `x-mcp-token` 또는 `Authorization: Bearer` 인증 요구. 비-loopback 배포는 이 값 또는 명시적 unauthenticated override가 필수
 - `ALLOW_QUERY_API_KEY`: `0`이면 `?oc=` 쿼리스트링 API 키를 무시 (프록시 액세스 로그 유출 차단). 기본 `1`
 - `RATE_LIMIT_RPM`: IP당 분당 요청 한도 (기본 `60`)
 - `FALLBACK_RATE_LIMIT_RPM`: 자체 키 없는 요청의 서버 LAW_OC 폴백 전역 상한 (기본 `120`, `0`이면 폴백 비활성)
 - `MCP_BODY_LIMIT`: POST body 한도 (기본 `100kb`)
 - `MCP_MAX_BATCH_CALLS`: 단일 POST(JSON-RPC 배치)에 허용하는 tools/call 최대 개수 (기본 `20`) — 배치 증폭으로 rate limit·폴백 쿼터 우회 차단
+- `MCP_MAX_UPSTREAM_REQUESTS`: 한 outer request가 사용할 수 있는 upstream attempt 수 (기본 `48`, 재시도/안티봇 hop 포함)
+- `MCP_MAX_UPSTREAM_BODY_BYTES` / `MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES`: 단일/전체 upstream 응답 본문 byte 한도
+- `MCP_MAX_TOOL_RESPONSE_CHARS`: MCP 도구 응답 문자 한도 (기본 `50000`)
 
 ## Domain Knowledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thanks for improving Korean Law MCP. The repository layout, tool architecture, and local troubleshooting notes live in [the development guide](docs/DEVELOPMENT.md); please start there rather than duplicating implementation details here.
+
+## Prerequisites and setup
+
+- Node.js 22.12.0 or newer and the npm version bundled with it.
+- A current checkout based on `main`. Keep generated `build/` output and local credentials out of commits.
+- `LAW_OC` is needed for live 법제처 API calls, but not for the unit test suite.
+
+```bash
+npm ci --ignore-scripts
+npm run typecheck
+npm test
+npm run build
+npm run verify:package
+```
+
+`--ignore-scripts` is the supported CI-safe install path: it avoids optional transitive native postinstall downloaders while retaining the pure-JS annex/PDF parser used by this server. See the development guide for local API configuration, CLI use, and Docker details.
+
+## Change scope and pull requests
+
+- Open or reference an issue before changing behavior; keep each pull request focused on that issue or a clearly related set of issues.
+- Follow the existing TypeScript style and make the smallest change that owns the behavior at the actual consumer boundary.
+- Add or update focused regression tests for behavior changes. Run all four checks above; use `npm pack --dry-run` as an additional release-path check when touching packaging.
+- Do not commit `build/`, `node_modules/`, `.env`, API keys, captured production data, or unrelated local changes.
+- In the pull request, link the issue, explain the user-visible or security effect, list validation run, and call out deliberately untested external integrations or deployment assumptions.
+
+## Security reports
+
+Please do not open public issues for suspected vulnerabilities or exposed credentials. Report them privately through [GitHub Security Advisories](https://github.com/chrisryugj/korean-law-mcp/security/advisories/new), including reproduction details and impact. If that route is unavailable, contact the repository maintainer privately through GitHub rather than disclosing the details in an issue or pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ npm run build
 npm run verify:package
 ```
 
-`--ignore-scripts` is the supported CI-safe install path: it avoids optional transitive native postinstall downloaders while retaining the pure-JS annex/PDF parser used by this server. See the development guide for local API configuration, CLI use, and Docker details.
+Developer tooling needs platform-specific optional bindings, so contributor installs retain optional packages but suppress every lifecycle script with `--ignore-scripts`. Supported plugin, global, Docker, and published-runtime paths additionally use `--omit=optional`: Kordoc's optional OCR/ML/native graph is absent, while the required pure-JS PDF runtime remains a normal pinned dependency. CI prunes to that production graph and runs `npm run verify:annex-runtime`. See the development guide for local API configuration, CLI use, and Docker details.
 
 ## Change scope and pull requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
 # Korean Law MCP Server - Docker 배포용
 
 # --- Build Stage ---
-FROM node:20-alpine AS builder
+# Node 22.12.0 LTS, pinned by immutable multi-architecture manifest digest.
+FROM node:22.12.0-alpine@sha256:51eff88af6dff26f59316b6e356188ffa2c422bd3c3b76f2556a2e7e89d080bd AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+# Kordoc keeps native OCR/ML helpers optional.  This server does not import
+# them, so do not run transitive postinstall downloaders during image builds.
+# Pure-JS annex parsing remains installed and is verified in CI.
+RUN npm ci --ignore-scripts
 
 COPY src ./src
+COPY scripts ./scripts
 COPY tsconfig.json ./
 
 RUN npm run build
-RUN npm prune --production
+RUN npm prune --omit=dev --ignore-scripts
 
 # --- Runtime Stage ---
-FROM node:20-alpine
+FROM node:22.12.0-alpine@sha256:51eff88af6dff26f59316b6e356188ffa2c422bd3c3b76f2556a2e7e89d080bd
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,15 @@ COPY package*.json ./
 # Kordoc keeps native OCR/ML helpers optional.  This server does not import
 # them, so do not run transitive postinstall downloaders during image builds.
 # Pure-JS annex parsing remains installed and is verified in CI.
-RUN npm ci --ignore-scripts
+RUN npm ci --ignore-scripts --omit=optional
 
 COPY src ./src
 COPY scripts ./scripts
 COPY tsconfig.json ./
 
 RUN npm run build
-RUN npm prune --omit=dev --ignore-scripts
+RUN npm prune --omit=dev --omit=optional --ignore-scripts
+RUN npm run verify:annex-runtime
 
 # --- Runtime Stage ---
 FROM node:22.12.0-alpine@sha256:51eff88af6dff26f59316b6e356188ffa2c422bd3c3b76f2556a2e7e89d080bd
@@ -38,6 +39,10 @@ EXPOSE 3000
 
 ENV NODE_ENV=production
 ENV PORT=3000
+# A container is explicitly a remote deployment unit. Bind externally, but
+# fail startup unless the operator supplies MCP_AUTH_TOKEN (or deliberately
+# opts into MCP_ALLOW_UNAUTHENTICATED_REMOTE at runtime).
+ENV MCP_HTTP_HOST=0.0.0.0
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1

--- a/README-EN.md
+++ b/README-EN.md
@@ -249,7 +249,7 @@ This project wraps that entire legal system into **14 structured tools** that an
 **Auto setup (recommended):**
 
 ```bash
-npx korean-law-mcp setup
+npx --ignore-scripts --omit=optional korean-law-mcp setup
 ```
 
 Interactive wizard handles API key input, client selection, and config file registration.
@@ -258,7 +258,7 @@ Supports Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, Gemini CLI, Zed
 **Manual setup:**
 
 ```bash
-npm install -g korean-law-mcp
+npm install --ignore-scripts --omit=optional -g korean-law-mcp
 ```
 
 Add to your MCP client config:
@@ -334,7 +334,7 @@ Get your free API key at [법제처 Open API](https://open.law.go.kr/LSO/openApi
 ### Option 3: CLI
 
 ```bash
-npm install -g korean-law-mcp
+npm install --ignore-scripts --omit=optional -g korean-law-mcp
 export LAW_OC=your-api-key
 
 korean-law search_law --query "관세법"
@@ -441,7 +441,7 @@ MCP_HTTP_HOST=0.0.0.0 TRUST_PROXY=1 MCP_AUTH_TOKEN=replace-with-a-secret \
 
 ### Dependency and install boundary
 
-The unused direct `pdfjs-dist` dependency is not shipped. `kordoc` remains because annex parsing is a reachable server feature; its optional OCR/ML/native helpers are not imported by this server. CI and Docker install with `--ignore-scripts`, so optional transitive native postinstall downloaders do not run in those build environments; the pure-JS PDF annex parser is covered by a smoke test. Scanner reports for transitive HTTP-framework packages should be evaluated against the reachable server path rather than treated as proof that the server exposes the affected middleware.
+`kordoc` remains because annex parsing is a reachable server feature. Its known-good pure-JS `pdfjs-dist@4.10.38` runtime is pinned as a normal dependency; optional OCR/ML/native helpers are not needed by this server. Plugin, documented, and Docker installs use `--omit=optional --ignore-scripts`. CI and publishing retain optional development-tool bindings with scripts disabled during validation, then prune to the production graph and run the PDF annex smoke test. Scanner reports for transitive HTTP-framework packages should be evaluated against the reachable server path rather than treated as proof that the server exposes the affected middleware.
 
 ## Documentation
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -349,7 +349,8 @@ korean-law help search_law               # tool help
 
 ```bash
 docker build -t korean-law-mcp .
-docker run -e LAW_OC=your-api-key -p 3000:3000 korean-law-mcp
+docker run -e LAW_OC=your-api-key -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_AUTH_TOKEN=replace-with-a-secret -p 3000:3000 korean-law-mcp
 ```
 
 ---
@@ -409,12 +410,38 @@ User: "산업안전보건법 별표1 내용"
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `LAW_OC` | Yes | — | 법제처 API key ([get one free](https://open.law.go.kr/LSO/openApi/guideResult.do)) |
-| `PORT` | No | 3000 | HTTP server port |
+| `PORT` | No | 8000 | HTTP server port |
 | `CORS_ORIGIN` | No | `*` | CORS allowed origin. Setting it explicitly also allows that origin to pass Origin validation |
 | `ALLOWED_ORIGINS` | No | — | Comma-separated origin allowlist. Requests carrying an `Origin` header are rejected unless listed (DNS rebinding defense) |
-| `MCP_AUTH_TOKEN` | No | — | When set, `/mcp` requires `x-mcp-token` or `Authorization: Bearer`. Required for closed-network / intranet deployments |
+| `MCP_AUTH_TOKEN` | No | — | When set, `/mcp` requires `x-mcp-token` or `Authorization: Bearer`. Required for non-loopback deployments unless explicitly overridden |
+| `MCP_HTTP_HOST` | No | `127.0.0.1` | Bind address. A non-loopback host requires `MCP_AUTH_TOKEN`, unless the deliberate legacy override below is set |
+| `MCP_ALLOW_UNAUTHENTICATED_REMOTE` | No | `0` | Set to `1` only for a deliberately public, non-loopback deployment without MCP access authentication |
+| `TRUST_PROXY` | No | `false` | Set to a positive proxy-hop count (for example `1` behind one Fly/ingress proxy). Never use `true`/`all` |
 | `ALLOW_QUERY_API_KEY` | No | `1` | Set to `0` to reject the `?oc=` query-string API key (it leaks into proxy access logs) |
-| `RATE_LIMIT_RPM` | No | 60 | Requests per minute per IP |
+| `RATE_LIMIT_RPM` | No | 60 | Tool calls per minute per IP. `0` disables only the per-IP limiter; batch and execution limits remain active |
+| `MCP_MAX_BATCH_CALLS` | No | 20 | Maximum `tools/call` items in one JSON-RPC HTTP envelope |
+| `MCP_MAX_BODY_BYTES` | No | 102400 | Maximum incoming JSON request size. The older `MCP_BODY_LIMIT` (`100kb`, etc.) is accepted for compatibility |
+| `MCP_MAX_UPSTREAM_REQUESTS` | No | 48 | Request-wide upstream attempt budget, including retries and anti-bot hops |
+| `MCP_MAX_UPSTREAM_BODY_BYTES` | No | 2097152 | Maximum bytes read from one upstream response body |
+| `MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES` | No | 8388608 | Maximum upstream body bytes read by one outer request |
+| `MCP_MAX_TOOL_RESPONSE_CHARS` | No | 50000 | Maximum returned MCP tool-response characters |
+
+All numeric limits are validated as whole numbers during startup. Invalid values fail startup rather than weakening a limit. `legal_research` and other documented chain tools share the 48-attempt request budget; JSON-RPC batch siblings share accounting but retain independent MCP cancellation signals.
+
+### HTTP deployment defaults
+
+HTTP mode is local by default: it binds only to `127.0.0.1`, does not trust `X-Forwarded-For`, and leaves token authentication optional for that loopback-only use. For a reverse-proxy deployment, set both the explicit public bind and the exact trusted hop count, for example:
+
+```bash
+MCP_HTTP_HOST=0.0.0.0 TRUST_PROXY=1 MCP_AUTH_TOKEN=replace-with-a-secret \
+  korean-law-mcp --mode http --port 8000
+```
+
+`MCP_ALLOW_UNAUTHENTICATED_REMOTE=1` preserves intentionally public legacy deployments, but emits a startup warning and should only be used where another access boundary is in place.
+
+### Dependency and install boundary
+
+The unused direct `pdfjs-dist` dependency is not shipped. `kordoc` remains because annex parsing is a reachable server feature; its optional OCR/ML/native helpers are not imported by this server. CI and Docker install with `--ignore-scripts`, so optional transitive native postinstall downloaders do not run in those build environments; the pure-JS PDF annex parser is covered by a smoke test. Scanner reports for transitive HTTP-framework packages should be evaluated against the reachable server path rather than treated as proof that the server exposes the affected middleware.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ MCP 도구 설계에서 **도구 수 ≠ 기능 수**입니다.
 /plugin marketplace update korean-law-marketplace
 ```
 
-> 내부적으로 `npx korean-law-mcp@latest`를 실행하므로 npm에 배포된 최신 버전이 항상 사용됩니다.
+> 내부적으로 `npx --ignore-scripts --omit=optional korean-law-mcp@latest`를 실행하므로 npm에 배포된 최신 버전을 사용하되, 선택적 OCR·ML·네이티브 의존성은 설치하지 않고 설치 스크립트도 실행하지 않습니다.
 
 #### Troubleshooting: `Permission denied (publickey)` 에러
 
@@ -688,12 +688,12 @@ Claude Desktop은 원격 HTTP MCP 서버를 직접 연결하지 못하므로 `mc
 
 인터넷 없이 쓰고 싶거나, 원격 서버를 거치지 않으려면 직접 설치할 수 있습니다.
 
-**사전 준비:** [Node.js](https://nodejs.org) 18 이상이 설치되어 있어야 합니다.
+**사전 준비:** [Node.js](https://nodejs.org) 22.12 이상이 설치되어 있어야 합니다.
 
 **자동 설치 (추천):**
 
 ```bash
-npx korean-law-mcp setup
+npx --ignore-scripts --omit=optional korean-law-mcp setup
 ```
 
 설치 마법사가 API 키 입력 → AI 클라이언트 선택 → 설정 파일 자동 등록까지 한 번에 처리합니다.
@@ -702,7 +702,7 @@ Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, Gemini CLI, Zed, Antigra
 **수동 설치:**
 
 ```bash
-npm install -g korean-law-mcp
+npm install --ignore-scripts --omit=optional -g korean-law-mcp
 ```
 
 AI 앱 설정 파일에 아래 내용을 추가합니다 (`honggildong`을 본인 인증키로 바꾸세요):
@@ -730,7 +730,7 @@ AI 앱 설정 파일에 아래 내용을 추가합니다 (`honggildong`을 본�
 
 ```bash
 # 설치
-npm install -g korean-law-mcp
+npm install --ignore-scripts --omit=optional -g korean-law-mcp
 
 # 인증키 설정 (honggildong을 본인 키로 바꾸세요)
 export LAW_OC=honggildong        # Mac/Linux
@@ -912,7 +912,7 @@ v4.4.0에서 노출 도구를 통폐합했습니다 (컨텍스트 52% 감축). �
 - `RATE_LIMIT_RPM=0`은 IP별 제한만 끕니다. `MCP_MAX_BATCH_CALLS`(기본 20), 요청 본문, upstream 시도/응답 본문, 도구 응답 제한은 계속 적용됩니다.
 - `MCP_MAX_BODY_BYTES`, `MCP_MAX_UPSTREAM_REQUESTS`(기본 48), `MCP_MAX_UPSTREAM_BODY_BYTES`, `MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES`, `MCP_MAX_TOOL_RESPONSE_CHARS`는 시작 시 정수로 검증되며 잘못된 값은 서버 시작을 실패시킵니다. 기존 `MCP_BODY_LIMIT=100kb`도 호환됩니다.
 - `get_batch_articles`는 최대 20개 법령·총 100개 조문으로 제한됩니다. HTTP 연결 종료 또는 MCP 취소는 fetch, 재시도 대기, 응답 본문 읽기까지 전파됩니다. JSON-RPC 배치 항목은 예산만 공유하고 취소 신호는 서로 분리됩니다.
-- publish 전 `build/`를 삭제하고 실제 pack 파일과 exports를 검증합니다. 직접 사용하지 않는 `pdfjs-dist`는 제거했지만, `kordoc`는 별표 PDF/HWP 파싱에 실제 사용되므로 유지합니다. CI/Docker는 `--ignore-scripts`로 optional native postinstall downloader를 실행하지 않으며 PDF 별표 smoke test를 실행합니다. transitive scanner 경고는 실제 도달 가능한 서버 경로와 구분해 평가합니다.
+- publish 전 `build/`를 삭제하고 실제 pack 파일과 exports를 검증합니다. `kordoc`는 별표 PDF/HWP 파싱에 실제 사용되므로 유지하고, 필요한 pure-JS `pdfjs-dist@4.10.38`만 일반 의존성으로 고정합니다. 플러그인·문서·Docker 설치는 `--omit=optional --ignore-scripts`로 OCR/ML/native 선택 의존성을 제외합니다. CI·게시 workflow는 개발 도구의 optional binding을 설치하되 script는 끈 상태로 검증한 뒤, production graph로 prune하고 PDF 별표 smoke test를 실행합니다. transitive scanner 경고는 실제 도달 가능한 서버 경로와 구분해 평가합니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -906,6 +906,16 @@ v4.4.0에서 노출 도구를 통폐합했습니다 (컨텍스트 52% 감축). �
 
 ---
 
+## HTTP·실행 경계 설정
+
+- HTTP 기본 바인딩은 `MCP_HTTP_HOST=127.0.0.1`, 프록시 신뢰 기본값은 `TRUST_PROXY=false`입니다. 외부 바인딩은 `MCP_AUTH_TOKEN`을 설정해야 하며, 의도적으로 공개할 때만 `MCP_ALLOW_UNAUTHENTICATED_REMOTE=1`을 명시합니다. 프록시 뒤에서는 `TRUST_PROXY=1`처럼 정확한 hop 수를 설정하세요.
+- `RATE_LIMIT_RPM=0`은 IP별 제한만 끕니다. `MCP_MAX_BATCH_CALLS`(기본 20), 요청 본문, upstream 시도/응답 본문, 도구 응답 제한은 계속 적용됩니다.
+- `MCP_MAX_BODY_BYTES`, `MCP_MAX_UPSTREAM_REQUESTS`(기본 48), `MCP_MAX_UPSTREAM_BODY_BYTES`, `MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES`, `MCP_MAX_TOOL_RESPONSE_CHARS`는 시작 시 정수로 검증되며 잘못된 값은 서버 시작을 실패시킵니다. 기존 `MCP_BODY_LIMIT=100kb`도 호환됩니다.
+- `get_batch_articles`는 최대 20개 법령·총 100개 조문으로 제한됩니다. HTTP 연결 종료 또는 MCP 취소는 fetch, 재시도 대기, 응답 본문 읽기까지 전파됩니다. JSON-RPC 배치 항목은 예산만 공유하고 취소 신호는 서로 분리됩니다.
+- publish 전 `build/`를 삭제하고 실제 pack 파일과 exports를 검증합니다. 직접 사용하지 않는 `pdfjs-dist`는 제거했지만, `kordoc`는 별표 PDF/HWP 파싱에 실제 사용되므로 유지합니다. CI/Docker는 `--ignore-scripts`로 optional native postinstall downloader를 실행하지 않으며 PDF 별표 smoke test를 실행합니다. transitive scanner 경고는 실제 도달 가능한 서버 경로와 구분해 평가합니다.
+
+---
+
 ## 문서
 
 - [docs/API.md](docs/API.md) — 도구 레퍼런스

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ get_annexes(lawName="여권법 시행령", bylSeq="000000")
 ### Remote (Fly.io)
 
 - **fly.toml**: 256MB 메모리, auto suspend/resume
-- **Dockerfile**: multi-stage build (node:20-alpine)
+- **Dockerfile**: multi-stage build (Node 22.12.0 Alpine image pinned by digest; install scripts disabled for optional native helpers)
 - **Health check**: `GET /health` (30초 간격)
 - **Endpoint**: `https://mcp.gomdori.app/law`
   - 구 `https://korean-law-mcp.fly.dev/mcp` 도 하위호환으로 계속 동작한다 — 통합 호스트가 이 fly 앱 위에 떠 있고, 프리픽스 없는 요청을 law 로 원경로 전달하기 때문. 신규 안내는 공식 주소로.
@@ -194,7 +194,8 @@ get_annexes(lawName="여권법 시행령", bylSeq="000000")
 
 ```bash
 docker build -t korean-law-mcp .
-docker run -e LAW_OC=your-key -p 3000:3000 korean-law-mcp
+docker run -e LAW_OC=your-key -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_AUTH_TOKEN=replace-with-a-secret -p 3000:3000 korean-law-mcp
 ```
 
 ---

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,8 +8,8 @@
 
 ### 요구사항
 
-- **Node.js**: 18.0.0 이상
-- **npm**: 9.0.0 이상
+- **Node.js**: 22.12.0 이상
+- **npm**: Node.js 22.12.0에 포함된 버전 이상
 - **TypeScript**: 5.7+ (프로젝트 종속성에 포함)
 
 ### 초기 설정
@@ -17,7 +17,7 @@
 ```bash
 git clone https://github.com/chrisryugj/korean-law-mcp.git
 cd korean-law-mcp
-npm install
+npm ci --ignore-scripts
 npm run build
 LAW_OC=your-api-key node build/index.js
 ```
@@ -181,9 +181,11 @@ Conventional Commits:
 
 ```bash
 npm version patch  # 버전 bump
-npm run build
-npm publish
+git push --follow-tags
+gh release create v$(node -p 'require("./package.json").version') --generate-notes
 ```
+
+GitHub Release가 `.github/workflows/publish.yml`을 실행합니다. npm 패키지 설정에서 이 저장소와 `publish.yml`을 trusted publisher로 먼저 등록해야 하며, workflow는 OIDC로 게시하고 provenance attestation을 자동 생성합니다. 로컬 `npm publish`와 장기 npm 토큰은 사용하지 않습니다.
 
 ### Fly.io
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -195,7 +195,8 @@ flyctl deploy
 
 ```bash
 docker build -t korean-law-mcp .
-docker run -e LAW_OC=your-key -p 3000:3000 korean-law-mcp
+docker run -e LAW_OC=your-key -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_AUTH_TOKEN=replace-with-a-secret -p 3000:3000 korean-law-mcp
 ```
 
 ---

--- a/knip.json
+++ b/knip.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "project": ["src/**/*.ts"]
+  "project": ["src/**/*.ts"],
+  "ignoreDependencies": ["pdfjs-dist"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "kordoc": "^4.7.2",
+        "pdfjs-dist": "4.10.38",
         "zod": "^4.0.0"
       },
       "bin": {
@@ -31,31 +32,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -3319,19 +3295,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/kordoc/node_modules/pdfjs-dist": {
-      "version": "4.10.38",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
-      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.65"
-      }
-    },
     "node_modules/kordoc/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -4017,6 +3980,18 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "kordoc": "^4.7.2",
-        "pdfjs-dist": "^5.5.207",
         "zod": "^4.0.0"
       },
       "bin": {
@@ -31,19 +30,31 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
@@ -3072,9 +3083,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.29",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
-      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3145,9 +3156,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3774,13 +3785,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-readable-to-web-readable-stream": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
-      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4013,19 +4017,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pdfjs-dist": {
-      "version": "5.6.205",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
-      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.19.0 || >=22.13.0 || >=24"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.96",
-        "node-readable-to-web-readable-stream": "^0.4.2"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typecheck": "tsc --noEmit",
     "dead-code": "knip",
     "gc": "npm run typecheck && npm run dead-code && npm test && npm run build",
+    "verify:annex-runtime": "node ./scripts/verify-annex-runtime.mjs",
     "verify:package": "node ./scripts/verify-package.mjs",
     "prepack": "npm run build && npm run verify:package",
     "prepublishOnly": "npm run build && npm run verify:package",
@@ -64,6 +65,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "kordoc": "^4.7.2",
+    "pdfjs-dist": "4.10.38",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "korean-law": "build/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "clean": "node ./scripts/clean-build.mjs",
+    "build": "npm run clean && tsc",
     "watch": "tsc --watch",
     "start": "node build/index.js",
     "cli": "node build/cli.js",
@@ -37,7 +38,9 @@
     "typecheck": "tsc --noEmit",
     "dead-code": "knip",
     "gc": "npm run typecheck && npm run dead-code && npm test && npm run build",
-    "prepublishOnly": "npm run build",
+    "verify:package": "node ./scripts/verify-package.mjs",
+    "prepack": "npm run build && npm run verify:package",
+    "prepublishOnly": "npm run build && npm run verify:package",
     "prepare": "husky"
   },
   "keywords": [
@@ -61,7 +64,6 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "kordoc": "^4.7.2",
-    "pdfjs-dist": "^5.5.207",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -73,7 +75,8 @@
     "vitest": "^4.1.9"
   },
   "overrides": {
-    "hono": "^4.12.29",
+    "hono": "^4.13.1",
+    "ip-address": "^10.5.0",
     "sharp": "^0.35.3",
     "adm-zip": "^0.6.0",
     "onnxruntime-node": "^1.27.0"
@@ -89,6 +92,6 @@
     "url": "git+https://github.com/chrisryugj/korean-law-mcp.git"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.12.0"
   }
 }

--- a/scripts/clean-build.mjs
+++ b/scripts/clean-build.mjs
@@ -1,0 +1,18 @@
+import { existsSync, lstatSync, rmSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const buildDir = resolve(root, "build")
+
+// Never make a recursive cleanup depend on an environment variable or a path
+// outside this package root.  Build is the only generated publish directory.
+if (dirname(buildDir) !== root) {
+  throw new Error("Refusing to clean an unexpected build directory.")
+}
+if (existsSync(buildDir)) {
+  if (!lstatSync(buildDir).isDirectory()) {
+    throw new Error("Refusing to remove build because it is not a directory.")
+  }
+  rmSync(buildDir, { recursive: true, force: false })
+}

--- a/scripts/verify-annex-runtime.mjs
+++ b/scripts/verify-annex-runtime.mjs
@@ -1,8 +1,6 @@
-import { describe, expect, it } from "vitest"
-import { parseAnnexFile } from "./annex-file-parser.js"
+import { parseAnnexFile } from "../build/lib/annex-file-parser.js"
 
-/** Construct a tiny valid text PDF without adding a PDF-generation dependency. */
-function minimalPdf(text: string): ArrayBuffer {
+function minimalPdf(text) {
   const stream = `BT\n/F1 12 Tf\n72 720 Td\n(${text}) Tj\nET\n`
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
@@ -24,14 +22,12 @@ function minimalPdf(text: string): ArrayBuffer {
   pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`
 
   const bytes = new TextEncoder().encode(pdf)
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
 }
 
-describe("annex file parser", () => {
-  it("parses a text PDF when the optional native dependency graph is omitted", async () => {
-    const result = await parseAnnexFile(minimalPdf("Annex parser smoke test"))
-    expect(result.fileType).toBe("pdf")
-    expect(result.success).toBe(true)
-    expect(result.markdown).toContain("Annex parser smoke test")
-  })
-})
+const result = await parseAnnexFile(minimalPdf("Annex runtime smoke test"))
+if (!result.success || result.fileType !== "pdf" || !result.markdown?.includes("Annex runtime smoke test")) {
+  throw new Error(`Annex runtime smoke test failed: ${JSON.stringify(result)}`)
+}
+
+console.log("annex runtime verified without optional dependencies")

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import { spawnSync } from "node:child_process"
+import { dirname, relative, resolve, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const buildDir = resolve(root, "build")
+const sourceDir = resolve(root, "src")
+const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"))
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function walk(directory) {
+  const entries = []
+  for (const name of readdirSync(directory)) {
+    const path = resolve(directory, name)
+    if (statSync(path).isDirectory()) entries.push(...walk(path))
+    else entries.push(path)
+  }
+  return entries
+}
+
+function sourcePathForBuildFile(buildFile) {
+  const relativeBuildPath = relative(buildDir, buildFile)
+  if (relativeBuildPath.endsWith(".d.ts")) {
+    return resolve(sourceDir, relativeBuildPath.slice(0, -".d.ts".length) + ".ts")
+  }
+  if (relativeBuildPath.endsWith(".js")) {
+    return resolve(sourceDir, relativeBuildPath.slice(0, -".js".length) + ".ts")
+  }
+  return undefined
+}
+
+function assertPathInPackage(path, label) {
+  const resolved = resolve(root, path)
+  assert(resolved === root || resolved.startsWith(`${root}${sep}`), `${label} resolves outside the package.`)
+  assert(existsSync(resolved), `${label} is missing from the clean build: ${path}`)
+}
+
+function verifyExportTargets(value, label = "exports") {
+  if (typeof value === "string") {
+    if (value.includes("*")) {
+      const prefix = value.slice(0, value.indexOf("*"))
+      assertPathInPackage(prefix, label)
+    } else {
+      assertPathInPackage(value, label)
+    }
+    return
+  }
+  if (value && typeof value === "object") {
+    for (const [key, target] of Object.entries(value)) verifyExportTargets(target, `${label}.${key}`)
+  }
+}
+
+function packedFiles() {
+  const result = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+    cwd: root,
+    encoding: "utf8",
+  })
+  if (result.status !== 0) {
+    throw new Error(`npm pack --dry-run failed:\n${result.stderr || result.stdout}`)
+  }
+  const output = result.stdout.trim()
+  const start = output.indexOf("[")
+  assert(start >= 0, "npm pack --dry-run did not return JSON.")
+  const pack = JSON.parse(output.slice(start))
+  assert(Array.isArray(pack) && pack.length === 1 && Array.isArray(pack[0].files), "npm pack --dry-run returned an unexpected file list.")
+  return pack[0].files.map(file => file.path)
+}
+
+export function verifyPackageArtifacts() {
+  assert(existsSync(buildDir), "build/ is missing. Run npm run build before verification.")
+
+  for (const buildFile of walk(buildDir)) {
+    const sourceFile = sourcePathForBuildFile(buildFile)
+    if (sourceFile) {
+      assert(existsSync(sourceFile), `Stale build output has no source module: ${relative(root, buildFile)}`)
+    }
+  }
+
+  assertPathInPackage(packageJson.main, "main")
+  assertPathInPackage(packageJson.types, "types")
+  for (const [name, target] of Object.entries(packageJson.bin ?? {})) {
+    assertPathInPackage(target, `bin.${name}`)
+  }
+  verifyExportTargets(packageJson.exports)
+
+  const allowedTopLevel = new Set(["README.md", "LICENSE", "NOTICE", "package.json"])
+  const files = packedFiles()
+  for (const file of files) {
+    assert(file.startsWith("build/") || allowedTopLevel.has(file), `Unexpected packed artifact: ${file}`)
+    assert(!file.includes("sse-server"), `Stale server artifact would be published: ${file}`)
+  }
+
+  console.log(`package artifacts verified (${files.length} packed files)`)
+}
+
+verifyPackageArtifacts()

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { LawApiClient } from "./lib/api-client.js"
 import { registerTools } from "./tool-registry.js"
 import { startHTTPServer } from "./server/http-server.js"
+import { parseHttpPort } from "./server/http-config.js"
+import { readExecutionLimits, type ExecutionLimits } from "./lib/execution-limits.js"
 import { VERSION } from "./version.js"
 
 // API 클라이언트 초기화 (LAW_OC 또는 KOREAN_LAW_API_KEY 지원)
@@ -17,12 +19,12 @@ const LAW_OC = process.env.LAW_OC || process.env.KOREAN_LAW_API_KEY || ""
 const apiClient = new LawApiClient({ apiKey: LAW_OC })
 
 // MCP 서버 팩토리 (HTTP 모드: 세션마다 새 인스턴스 필요)
-function createServer(): Server {
+function createServer(executionLimits: ExecutionLimits = readExecutionLimits()): Server {
   const s = new Server(
     { name: "korean-law", version: VERSION },
     { capabilities: { tools: {} } }
   )
-  registerTools(s, apiClient)
+  registerTools(s, apiClient, executionLimits)
   return s
 }
 
@@ -40,7 +42,7 @@ async function main() {
   const modeIndex = args.indexOf("--mode")
   const mode = modeIndex !== -1 ? args[modeIndex + 1] : "stdio"
   const portIndex = args.indexOf("--port")
-  const port = portIndex !== -1 ? parseInt(args[portIndex + 1], 10) : 8000
+  const port = parseHttpPort(portIndex !== -1 ? args[portIndex + 1] : undefined)
 
   if (mode === "http" || mode === "sse") {
     await startHTTPServer(createServer, port)

--- a/src/lib/annex-file-parser.test.ts
+++ b/src/lib/annex-file-parser.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { parseAnnexFile } from "./annex-file-parser.js"
+
+/** Construct a tiny valid text PDF without adding a PDF-generation dependency. */
+function minimalPdf(text: string): ArrayBuffer {
+  const stream = `BT\n/F1 12 Tf\n72 720 Td\n(${text}) Tj\nET\n`
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}endstream`,
+  ]
+
+  let pdf = "%PDF-1.4\n"
+  const offsets = [0]
+  for (let index = 0; index < objects.length; index++) {
+    offsets.push(Buffer.byteLength(pdf))
+    pdf += `${index + 1} 0 obj\n${objects[index]}\nendobj\n`
+  }
+  const xrefOffset = Buffer.byteLength(pdf)
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`
+  for (const offset of offsets.slice(1)) pdf += `${String(offset).padStart(10, "0")} 00000 n \n`
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`
+
+  const bytes = new TextEncoder().encode(pdf)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
+describe("annex file parser", () => {
+  it("parses a text PDF when optional native install scripts are disabled", async () => {
+    const result = await parseAnnexFile(minimalPdf("Annex parser smoke test"))
+    expect(result.fileType).toBe("pdf")
+    expect(result.success).toBe(true)
+    expect(result.markdown).toContain("Annex parser smoke test")
+  })
+})

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -4,6 +4,7 @@
 
 import { normalizeLawSearchText, resolveLawAlias } from "./search-normalizer.js"
 import { fetchWithRetry } from "./fetch-with-retry.js"
+import { readResponseText } from "./response-body.js"
 
 // 법제처 DRF는 정상 파라미터에도 연속 호출 버스트에 간헐 404를 낸다
 // (2026-07-19 행위시법 골드셋 R1에서 19콜 중 10콜 관측, 수초 내 자연 회복 —
@@ -42,7 +43,7 @@ export class LawApiClient {
   private async throwIfError(response: Response, endpoint: string): Promise<void> {
     if (!response.ok) {
       // body stream 리크 방지: throw 전에 body consume
-      try { await response.text() } catch { /* ignore */ }
+      try { await readResponseText(response) } catch { /* ignore */ }
       const status = response.status
       if (status === 429) throw new Error(`API 요청 한도 초과 (429) - 잠시 후 다시 시도하세요.`)
       if (status >= 500) throw new Error(`법제처 서버 오류 (${status}) - ${endpoint}`)
@@ -99,7 +100,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "searchLaw")
 
-    const text = await response.text()
+    const text = await readResponseText(response)
     this.checkEmptyResponse(text, "법령 검색")
     this.checkHtmlError(text, "법령 검색 결과를 받지 못했습니다")
     return text
@@ -130,7 +131,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getLawText")
 
-    const text = await response.text()
+    const text = await readResponseText(response)
 
     this.checkHtmlError(text, params.jo
       ? `법령 조문(${params.jo})을 찾을 수 없습니다. MST/lawId와 조문번호를 확인해주세요.`
@@ -164,7 +165,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "compareOldNew")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 
   /**
@@ -190,7 +191,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getThreeTier")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 
   /**
@@ -214,7 +215,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "searchAdminRule")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 
   /**
@@ -232,7 +233,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getAdminRule")
 
-    const text = await response.text()
+    const text = await readResponseText(response)
     this.checkHtmlError(text, "행정규칙을 찾을 수 없습니다. ID를 확인해주세요")
 
     return text
@@ -274,7 +275,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getAnnexes")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 
   /**
@@ -321,7 +322,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "searchOrdinance")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 
   /**
@@ -340,7 +341,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getOrdinance")
 
-    const text = await response.text()
+    const text = await readResponseText(response)
     this.checkHtmlError(text, "자치법규를 찾을 수 없습니다. ordinSeq를 확인해주세요")
 
     return text
@@ -377,7 +378,7 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getArticleHistory")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 
   /**
@@ -412,7 +413,7 @@ export class LawApiClient {
     )
     await this.throwIfError(response, `fetchApi(${params.target})`)
 
-    const text = await response.text()
+    const text = await readResponseText(response)
     // type=HTML 응답은 HTML이 정상 — checkHtmlError(XML/JSON 응답에 HTML이 오면 에러) 우회
     if (params.type !== "HTML") {
       this.checkHtmlError(text, "API 응답 오류 - 파라미터를 확인해주세요")
@@ -446,6 +447,6 @@ export class LawApiClient {
     const response = await fetchWithRetry(url, DRF_RETRY)
     await this.throwIfError(response, "getLawHistory")
 
-    return await response.text()
+    return await readResponseText(response)
   }
 }

--- a/src/lib/execution-limits.test.ts
+++ b/src/lib/execution-limits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import { DEFAULT_EXECUTION_LIMITS, ExecutionLimitError, RequestExecutionBudget, readExecutionLimits } from "./execution-limits.js"
-import { sleep } from "./fetch-with-retry.js"
+import { fetchWithRetry, sleep } from "./fetch-with-retry.js"
 import { readResponseText } from "./response-body.js"
 import { requestContext, runWithRequestContext } from "./session-state.js"
 
@@ -51,6 +51,31 @@ describe("request-wide execution limits", () => {
     const pending = sleep(10_000, controller.signal)
     controller.abort("client cancelled")
     await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+  })
+
+  it("cancels a discarded retry response and its status backoff", async () => {
+    const controller = new AbortController()
+    const cancelBody = vi.fn()
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      new ReadableStream<Uint8Array>({ cancel: cancelBody }),
+      { status: 503, headers: { "Retry-After": "10" } },
+    ))
+    vi.stubGlobal("fetch", fetchMock)
+
+    try {
+      const pending = requestContext.run({ signal: controller.signal }, () => fetchWithRetry(
+        "https://example.invalid/retry",
+        { retries: 1 },
+      ))
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+      controller.abort("client cancelled")
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+      expect(cancelBody).toHaveBeenCalledTimes(1)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it("keeps MCP cancellation item-scoped while batch accounting is shared", () => {

--- a/src/lib/execution-limits.test.ts
+++ b/src/lib/execution-limits.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest"
+import { DEFAULT_EXECUTION_LIMITS, ExecutionLimitError, RequestExecutionBudget, readExecutionLimits } from "./execution-limits.js"
+import { sleep } from "./fetch-with-retry.js"
+import { readResponseText } from "./response-body.js"
+import { requestContext, runWithRequestContext } from "./session-state.js"
+
+describe("request-wide execution limits", () => {
+  it("charges every upstream attempt against one shared budget", () => {
+    const budget = new RequestExecutionBudget({ ...DEFAULT_EXECUTION_LIMITS, maxUpstreamRequests: 2 })
+    budget.consumeUpstreamRequest()
+    budget.consumeUpstreamRequest()
+    expect(() => budget.consumeUpstreamRequest()).toThrow(ExecutionLimitError)
+    expect(budget.snapshot().upstreamRequests).toBe(3)
+  })
+
+  it("stops an oversized upstream response before buffering it", async () => {
+    const budget = new RequestExecutionBudget({
+      ...DEFAULT_EXECUTION_LIMITS,
+      maxUpstreamBodyBytes: 4,
+      maxTotalUpstreamBodyBytes: 8,
+    })
+    await expect(requestContext.run({ budget }, () => readResponseText(new Response("12345"))))
+      .rejects.toThrow(ExecutionLimitError)
+  })
+
+  it("shares the total body allowance across reads in one outer request", async () => {
+    const budget = new RequestExecutionBudget({
+      ...DEFAULT_EXECUTION_LIMITS,
+      maxUpstreamBodyBytes: 8,
+      maxTotalUpstreamBodyBytes: 5,
+    })
+    await requestContext.run({ budget }, async () => {
+      await expect(readResponseText(new Response("123"))).resolves.toBe("123")
+      await expect(readResponseText(new Response("456"))).rejects.toThrow(ExecutionLimitError)
+    })
+  })
+
+  it("cancels a pending body read", async () => {
+    const controller = new AbortController()
+    const cancel = vi.fn()
+    const response = new Response(new ReadableStream<Uint8Array>({ cancel }))
+    const pending = requestContext.run({ signal: controller.signal }, () => readResponseText(response))
+
+    controller.abort("client cancelled")
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it("interrupts retry backoff when the MCP item is cancelled", async () => {
+    const controller = new AbortController()
+    const pending = sleep(10_000, controller.signal)
+    controller.abort("client cancelled")
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+  })
+
+  it("keeps MCP cancellation item-scoped while batch accounting is shared", () => {
+    const connection = new AbortController()
+    const firstItem = new AbortController()
+    const secondItem = new AbortController()
+    const budget = new RequestExecutionBudget(DEFAULT_EXECUTION_LIMITS)
+    let firstSignal: AbortSignal | undefined
+    let secondSignal: AbortSignal | undefined
+
+    requestContext.run({ signal: connection.signal, budget }, () => {
+      runWithRequestContext({ signal: firstItem.signal }, () => {
+        firstSignal = requestContext.getStore()?.signal
+        expect(requestContext.getStore()?.budget).toBe(budget)
+      })
+      runWithRequestContext({ signal: secondItem.signal }, () => {
+        secondSignal = requestContext.getStore()?.signal
+        expect(requestContext.getStore()?.budget).toBe(budget)
+      })
+    })
+
+    firstItem.abort("first item cancelled")
+    expect(firstSignal?.aborted).toBe(true)
+    expect(secondSignal?.aborted).toBe(false)
+
+    connection.abort("connection closed")
+    expect(secondSignal?.aborted).toBe(true)
+  })
+
+  it("rejects malformed execution limit values instead of treating them as disabled", () => {
+    expect(() => readExecutionLimits({ MCP_MAX_UPSTREAM_REQUESTS: "48oops" })).toThrow(
+      "MCP_MAX_UPSTREAM_REQUESTS must be an integer",
+    )
+  })
+})

--- a/src/lib/execution-limits.ts
+++ b/src/lib/execution-limits.ts
@@ -1,0 +1,140 @@
+/**
+ * Request-wide execution limits.
+ *
+ * A single HTTP JSON-RPC envelope can contain a batch and a single tool can
+ * fan out into several upstream calls.  Keep the accounting object in the
+ * request context so those inner calls share one budget instead of each
+ * receiving a fresh allowance.
+ */
+
+export interface ExecutionLimits {
+  /** Total upstream HTTP attempts, including retries and anti-bot hops. */
+  maxUpstreamRequests: number
+  /** Maximum bytes read from one upstream response body. */
+  maxUpstreamBodyBytes: number
+  /** Maximum bytes read from all upstream response bodies in one request. */
+  maxTotalUpstreamBodyBytes: number
+  /** Maximum characters returned in an MCP tool response. */
+  maxToolResponseChars: number
+}
+
+export const DEFAULT_EXECUTION_LIMITS: ExecutionLimits = {
+  // document_review can legitimately issue 17 upstream calls.  48 leaves
+  // room for the documented chain workflows and bounded retry recovery while
+  // stopping unbounded fan-out from one outer MCP request.
+  maxUpstreamRequests: 48,
+  maxUpstreamBodyBytes: 2 * 1024 * 1024,
+  maxTotalUpstreamBodyBytes: 8 * 1024 * 1024,
+  maxToolResponseChars: 50_000,
+}
+
+const MAX_CONFIGURED_REQUESTS = 1_000
+const MAX_CONFIGURED_BYTES = 100 * 1024 * 1024
+const MAX_CONFIGURED_RESPONSE_CHARS = 1_000_000
+
+export class ExecutionLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "ExecutionLimitError"
+  }
+}
+
+/** Parse a security boundary as a whole integer; never accept parseInt's 12x → 12 behaviour. */
+export function parseIntegerLimit(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (raw === undefined) return fallback
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}.`)
+  }
+
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}.`)
+  }
+  return value
+}
+
+export function readExecutionLimits(env: NodeJS.ProcessEnv = process.env): ExecutionLimits {
+  const limits: ExecutionLimits = {
+    maxUpstreamRequests: parseIntegerLimit(
+      "MCP_MAX_UPSTREAM_REQUESTS",
+      env.MCP_MAX_UPSTREAM_REQUESTS,
+      DEFAULT_EXECUTION_LIMITS.maxUpstreamRequests,
+      1,
+      MAX_CONFIGURED_REQUESTS,
+    ),
+    maxUpstreamBodyBytes: parseIntegerLimit(
+      "MCP_MAX_UPSTREAM_BODY_BYTES",
+      env.MCP_MAX_UPSTREAM_BODY_BYTES,
+      DEFAULT_EXECUTION_LIMITS.maxUpstreamBodyBytes,
+      1_024,
+      MAX_CONFIGURED_BYTES,
+    ),
+    maxTotalUpstreamBodyBytes: parseIntegerLimit(
+      "MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES",
+      env.MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES,
+      DEFAULT_EXECUTION_LIMITS.maxTotalUpstreamBodyBytes,
+      1_024,
+      MAX_CONFIGURED_BYTES,
+    ),
+    maxToolResponseChars: parseIntegerLimit(
+      "MCP_MAX_TOOL_RESPONSE_CHARS",
+      env.MCP_MAX_TOOL_RESPONSE_CHARS,
+      DEFAULT_EXECUTION_LIMITS.maxToolResponseChars,
+      1_024,
+      MAX_CONFIGURED_RESPONSE_CHARS,
+    ),
+  }
+
+  if (limits.maxTotalUpstreamBodyBytes < limits.maxUpstreamBodyBytes) {
+    throw new Error("MCP_MAX_TOTAL_UPSTREAM_BODY_BYTES must be at least MCP_MAX_UPSTREAM_BODY_BYTES.")
+  }
+
+  return limits
+}
+
+/** Mutable per-request accounting; this object is intentionally shared by a JSON-RPC batch. */
+export class RequestExecutionBudget {
+  private upstreamRequests = 0
+  private upstreamBodyBytes = 0
+
+  constructor(readonly limits: ExecutionLimits) {}
+
+  consumeUpstreamRequest(): void {
+    this.upstreamRequests += 1
+    if (this.upstreamRequests > this.limits.maxUpstreamRequests) {
+      throw new ExecutionLimitError(
+        `Request upstream work budget exceeded (max ${this.limits.maxUpstreamRequests} attempts).`,
+      )
+    }
+  }
+
+  consumeUpstreamBody(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new ExecutionLimitError("Invalid upstream response body size.")
+    }
+    this.upstreamBodyBytes += bytes
+    if (this.upstreamBodyBytes > this.limits.maxTotalUpstreamBodyBytes) {
+      throw new ExecutionLimitError(
+        `Request upstream response-body budget exceeded (max ${this.limits.maxTotalUpstreamBodyBytes} bytes).`,
+      )
+    }
+  }
+
+  ensureResponseBodySize(bytes: number): void {
+    if (bytes > this.limits.maxUpstreamBodyBytes) {
+      throw new ExecutionLimitError(
+        `Upstream response body exceeds the per-response limit (${this.limits.maxUpstreamBodyBytes} bytes).`,
+      )
+    }
+  }
+
+  snapshot(): { upstreamRequests: number; upstreamBodyBytes: number } {
+    return { upstreamRequests: this.upstreamRequests, upstreamBodyBytes: this.upstreamBodyBytes }
+  }
+}

--- a/src/lib/external-https-proxy.ts
+++ b/src/lib/external-https-proxy.ts
@@ -1,6 +1,7 @@
 import http from "node:http"
 import net from "node:net"
 import tls from "node:tls"
+import { getRequestSignal, requestCancelledError, requestContext, throwIfRequestCancelled } from "./session-state.js"
 
 const DEFAULT_TIMEOUT = 30000
 
@@ -69,6 +70,8 @@ export async function requestExternalHttps(
   if (!config) {
     throw new Error("LAW_EXTERNAL_HTTPS_PROXY is not configured")
   }
+  throwIfRequestCancelled()
+  requestContext.getStore()?.budget?.consumeUpstreamRequest()
 
   const targetUrl = new URL(url)
   if (targetUrl.protocol !== "https:") {
@@ -101,8 +104,21 @@ export async function requestExternalHttps(
       timeout,
     }, (response) => {
       const chunks: Buffer[] = []
-      response.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+      let bodyBytes = 0
+      response.on("data", (chunk) => {
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        bodyBytes += bytes.byteLength
+        try {
+          const budget = requestContext.getStore()?.budget
+          budget?.ensureResponseBodySize(bodyBytes)
+          budget?.consumeUpstreamBody(bytes.byteLength)
+          chunks.push(bytes)
+        } catch (error) {
+          request.destroy(error instanceof Error ? error : new Error(String(error)))
+        }
+      })
       response.on("end", () => {
+        cleanupAbort()
         resolve({
           ok: response.statusCode ? response.statusCode >= 200 && response.statusCode < 300 : false,
           status: response.statusCode || 0,
@@ -110,12 +126,28 @@ export async function requestExternalHttps(
           text: Buffer.concat(chunks).toString("utf8"),
         })
       })
+      response.on("error", (error) => {
+        cleanupAbort()
+        reject(error)
+      })
     })
+
+    const signal = getRequestSignal()
+    const onAbort = () => request.destroy(requestCancelledError(signal?.reason))
+    const cleanupAbort = () => signal?.removeEventListener("abort", onAbort)
+    if (signal?.aborted) {
+      request.destroy(requestCancelledError(signal.reason))
+    } else {
+      signal?.addEventListener("abort", onAbort, { once: true })
+    }
 
     request.on("timeout", () => {
       request.destroy(new Error(`External HTTPS request timeout after ${timeout}ms`))
     })
-    request.on("error", reject)
+    request.on("error", (error) => {
+      cleanupAbort()
+      reject(error)
+    })
     if (body) request.write(body)
     request.end()
   })

--- a/src/lib/fetch-with-retry.ts
+++ b/src/lib/fetch-with-retry.ts
@@ -5,6 +5,9 @@
  */
 
 import { followLawAntibot } from "./law-antibot.js"
+import { ExecutionLimitError } from "./execution-limits.js"
+import { readResponseText } from "./response-body.js"
+import { combineAbortSignals, getRequestSignal, requestCancelledError, requestContext, throwIfRequestCancelled } from "./session-state.js"
 
 /**
  * URL에서 민감 정보(API 키) 마스킹 — 에러 메시지/로그 노출 방지.
@@ -84,24 +87,35 @@ export async function fetchWithRetry(
     retryDelay = DEFAULT_RETRY_DELAY,
     retryOn = DEFAULT_RETRY_ON,
     allowHtmlBody = false,
+    signal: callerSignal,
     ...fetchOptions
   } = options
+  const externalSignal = callerSignal ?? undefined
 
   let lastError: Error | null = null
 
   for (let attempt = 0; attempt <= retries; attempt++) {
+    throwIfRequestCancelled()
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), timeout)
+    let timedOut = false
+    const timeoutId = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, timeout)
+    const signal = combineAbortSignals(controller.signal, externalSignal, getRequestSignal())
 
     const headers = new Headers(fetchOptions.headers)
     if (!headers.has("user-agent")) headers.set("user-agent", DEFAULT_USER_AGENT)
     if (!headers.has("referer") && isLawGoKrHost(url)) headers.set("referer", DEFAULT_REFERER)
 
     try {
+      // This is intentionally charged per *attempt*: retry and anti-bot work
+      // must not turn one tool call into unbounded upstream activity.
+      requestContext.getStore()?.budget?.consumeUpstreamRequest()
       let response = await fetch(url, {
         ...fetchOptions,
         headers,
-        signal: controller.signal,
+        signal,
       })
 
       clearTimeout(timeoutId)
@@ -114,20 +128,32 @@ export async function fetchWithRetry(
           try {
             const bypassed = await followLawAntibot(response, url, headers, timeout)
             if (bypassed) response = bypassed
-          } catch { /* 우회 실패 시 원본 응답으로 진행 */ }
+          } catch (error) {
+            // Cancellation and budget exhaustion must stop the request rather
+            // than silently falling through to more work.
+            if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted || externalSignal?.aborted) {
+              throw error
+            }
+            // 우회 실패 시 원본 응답으로 진행
+          }
         }
         // 200인데 빈 본문/HTML(법제처 점검·과부하 페이지)이면 일시 장애로 보고 재시도.
         // 이를 막지 않으면 XML 파서가 "missing root element"로 터진다.
         if (response.ok && attempt < retries) {
           let bodyText: string | null = null
-          try { bodyText = await response.clone().text() } catch { /* clone 실패 시 정상 처리 */ }
+          try { bodyText = await readResponseText(response.clone()) } catch (error) {
+            if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted || externalSignal?.aborted) {
+              throw error
+            }
+            // clone 실패 시 정상 처리
+          }
           if (bodyText !== null) {
             const bad = detectBadBody(bodyText)
             if (bad === "empty" || (bad === "html" && !allowHtmlBody)) {
               lastError = new Error(
                 `법제처 API 비정상 응답(${bad === "empty" ? "빈 본문" : "HTML 페이지"}) - ${maskSensitiveUrl(url)}`
               )
-              await sleep(getRetryDelay(response, retryDelay, attempt))
+              await sleep(getRetryDelay(response, retryDelay, attempt), combineAbortSignals(externalSignal, getRequestSignal()))
               continue
             }
           }
@@ -147,9 +173,14 @@ export async function fetchWithRetry(
     } catch (error) {
       clearTimeout(timeoutId)
 
+      if (getRequestSignal()?.aborted || externalSignal?.aborted) {
+        throw requestCancelledError(getRequestSignal()?.reason ?? externalSignal?.reason)
+      }
+      if (error instanceof ExecutionLimitError) throw error
+
       // Timeout or network error — URL에서 API 키 제거 후 에러 생성
       if (error instanceof Error) {
-        if (error.name === "AbortError") {
+        if (error.name === "AbortError" && timedOut) {
           lastError = new Error(`Request timeout after ${timeout}ms for ${maskSensitiveUrl(url)}`)
         } else {
           // fetch 네이티브 에러 메시지에도 URL이 포함될 수 있음
@@ -161,7 +192,7 @@ export async function fetchWithRetry(
       // Retry on network errors
       if (attempt < retries) {
         const delay = getRetryDelay(null, retryDelay, attempt)
-        await sleep(delay)
+        await sleep(delay, combineAbortSignals(externalSignal, getRequestSignal()))
         continue
       }
     }
@@ -185,6 +216,20 @@ function getRetryDelay(response: Response | null, retryDelay: number, attempt: n
   return baseDelay + Math.random() * baseDelay * 0.5
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
+  if (signal.aborted) return Promise.reject(requestCancelledError(signal.reason))
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timeoutId)
+      signal.removeEventListener("abort", onAbort)
+      reject(requestCancelledError(signal.reason))
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
 }

--- a/src/lib/fetch-with-retry.ts
+++ b/src/lib/fetch-with-retry.ts
@@ -132,6 +132,7 @@ export async function fetchWithRetry(
             // Cancellation and budget exhaustion must stop the request rather
             // than silently falling through to more work.
             if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted || externalSignal?.aborted) {
+              await response.body?.cancel().catch(() => {})
               throw error
             }
             // 우회 실패 시 원본 응답으로 진행
@@ -141,10 +142,16 @@ export async function fetchWithRetry(
         // 이를 막지 않으면 XML 파서가 "missing root element"로 터진다.
         if (response.ok && attempt < retries) {
           let bodyText: string | null = null
-          try { bodyText = await readResponseText(response.clone()) } catch (error) {
+          const inspection = response.clone()
+          try { bodyText = await readResponseText(inspection) } catch (error) {
             if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted || externalSignal?.aborted) {
+              await Promise.allSettled([
+                inspection.body?.cancel(),
+                response.body?.cancel(),
+              ])
               throw error
             }
+            void inspection.body?.cancel().catch(() => {})
             // clone 실패 시 정상 처리
           }
           if (bodyText !== null) {
@@ -153,6 +160,7 @@ export async function fetchWithRetry(
               lastError = new Error(
                 `법제처 API 비정상 응답(${bad === "empty" ? "빈 본문" : "HTML 페이지"}) - ${maskSensitiveUrl(url)}`
               )
+              await response.body?.cancel().catch(() => {})
               await sleep(getRetryDelay(response, retryDelay, attempt), combineAbortSignals(externalSignal, getRequestSignal()))
               continue
             }
@@ -164,7 +172,11 @@ export async function fetchWithRetry(
       // Retryable error - check if we have retries left
       if (attempt < retries) {
         const delay = getRetryDelay(response, retryDelay, attempt)
-        await sleep(delay)
+        // This response will never be returned to a caller. Dispose its body
+        // before backoff so the connection can be reused, and let either MCP
+        // item cancellation or HTTP disconnect interrupt the wait.
+        await response.body?.cancel().catch(() => {})
+        await sleep(delay, combineAbortSignals(externalSignal, getRequestSignal()))
         continue
       }
 

--- a/src/lib/law-antibot.test.ts
+++ b/src/lib/law-antibot.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest"
-import { parseAntibotUrl } from "./law-antibot.js"
+import { afterEach, describe, it, expect, vi } from "vitest"
+import { followLawAntibot, parseAntibotUrl } from "./law-antibot.js"
+import { requestContext } from "./session-state.js"
+
+afterEach(() => vi.unstubAllGlobals())
 
 describe("parseAntibotUrl", () => {
   it("패턴 A(concat) — t+h+o 조합으로 리다이렉트 경로 복원", () => {
@@ -16,5 +19,90 @@ describe("parseAntibotUrl", () => {
   it("안티봇 패턴이 없으면 null", () => {
     expect(parseAntibotUrl("<html><body>정상 응답</body></html>")).toBeNull()
     expect(parseAntibotUrl("")).toBeNull()
+  })
+
+  it("releases a redirect response only after its replacement succeeds", async () => {
+    const original = new Response(
+      `<script>var x={t:'/DRF',h:'/next',o:'?token=1'};location.assign(x.t+x.h+x.o);</script>`,
+    )
+    const replacement = new Response("replacement")
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(replacement))
+
+    await expect(followLawAntibot(
+      original,
+      "https://www.law.go.kr/DRF/original",
+      new Headers(),
+      1_000,
+    )).resolves.toBe(replacement)
+    expect(original.bodyUsed).toBe(true)
+  })
+
+  it("preserves the original response when the replacement request fails", async () => {
+    const original = new Response(
+      `<script>var x={t:'/DRF',h:'/next',o:'?token=1'};location.assign(x.t+x.h+x.o);</script>`,
+    )
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network failed")))
+
+    await expect(followLawAntibot(
+      original,
+      "https://www.law.go.kr/DRF/original",
+      new Headers(),
+      1_000,
+    )).rejects.toThrow("network failed")
+    expect(original.bodyUsed).toBe(false)
+  })
+
+  it("preserves the root response when the 404 fallback fetch fails", async () => {
+    const original = new Response(
+      `<script>var x={t:'/DRF',h:'/next',o:'?token=1'};location.assign(x.t+x.h+x.o);</script>`,
+    )
+    const notFound = new Response("missing", { status: 404 })
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(notFound)
+      .mockRejectedValueOnce(new Error("fallback failed")))
+
+    await expect(followLawAntibot(
+      original,
+      "https://www.law.go.kr/DRF/original",
+      new Headers(),
+      1_000,
+    )).rejects.toThrow("fallback failed")
+    expect(original.bodyUsed).toBe(false)
+    expect(notFound.bodyUsed).toBe(true)
+  })
+
+  it("preserves the root response when a later anti-bot hop fails", async () => {
+    const redirect = `<script>var x={t:'/DRF',h:'/next',o:'?token=1'};location.assign(x.t+x.h+x.o);</script>`
+    const original = new Response(redirect)
+    const intermediate = new Response(redirect)
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(intermediate)
+      .mockRejectedValueOnce(new Error("later hop failed")))
+
+    await expect(followLawAntibot(
+      original,
+      "https://www.law.go.kr/DRF/original",
+      new Headers(),
+      1_000,
+    )).rejects.toThrow("later hop failed")
+    expect(original.bodyUsed).toBe(false)
+    expect(intermediate.bodyUsed).toBe(true)
+  })
+
+  it("releases the response when cancellation aborts inspection", async () => {
+    const controller = new AbortController()
+    const response = new Response("normal body")
+    controller.abort("cancelled")
+
+    await expect(requestContext.run(
+      { signal: controller.signal },
+      () => followLawAntibot(
+        response,
+        "https://www.law.go.kr/DRF/original",
+        new Headers(),
+        1_000,
+      ),
+    )).rejects.toMatchObject({ name: "AbortError" })
+    expect(response.bodyUsed).toBe(true)
   })
 })

--- a/src/lib/law-antibot.ts
+++ b/src/lib/law-antibot.ts
@@ -67,25 +67,43 @@ export async function followLawAntibot(
   timeout: number,
   maxHops = 3
 ): Promise<Response | null> {
+  const root = response
   let current = response
   let hopped = false
 
+  const finishWith = async (replacement: Response): Promise<Response> => {
+    if (replacement !== root) await root.body?.cancel().catch(() => {})
+    return replacement
+  }
+
   for (let hop = 0; hop < maxHops; hop++) {
     let text: string
+    const inspection = current.clone()
     try {
-      text = await readResponseText(current.clone())
+      text = await readResponseText(inspection)
     } catch (error) {
-      if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted) throw error
-      return hopped ? current : null
+      if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted) {
+        // `clone()` tees the body; cancelling one branch can wait for the
+        // other. Release both concurrently on terminal request errors.
+        await Promise.allSettled([
+          inspection.body?.cancel(),
+          current.body?.cancel(),
+        ])
+        throw error
+      }
+      // Keep `current` readable for the caller. Cancellation of the discarded
+      // inspection branch is initiated but must not block on the live tee.
+      void inspection.body?.cancel().catch(() => {})
+      return hopped ? await finishWith(current) : null
     }
 
     // 안티봇 페이지가 아니면 종료 (첫 홉이면 변경 없음 = null)
     if (!text.includes("location.assign")) {
-      return hopped ? current : null
+      return hopped ? await finishWith(current) : null
     }
 
     const path = parseAntibotUrl(text)
-    if (!path) return hopped ? current : null
+    if (!path) return hopped ? await finishWith(current) : null
 
     // path는 보통 절대경로(/DRF/...). 원본 URL의 origin에 붙인다.
     // path가 절대 URL이면 base가 무시되므로, 홉 대상이 원본과 같은 호스트인지
@@ -94,23 +112,44 @@ export async function followLawAntibot(
     try {
       const parsed = new URL(path, originalUrl)
       if (parsed.hostname !== new URL(originalUrl).hostname) {
-        return hopped ? current : null
+        return hopped ? await finishWith(current) : null
       }
       nextUrl = parsed.toString()
     } catch {
-      return hopped ? current : null
+      return hopped ? await finishWith(current) : null
     }
 
-    const next = await fetchOnce(nextUrl, headers, timeout)
+    let next: Response
+    try {
+      next = await fetchOnce(nextUrl, headers, timeout)
+    } catch (error) {
+      // An intermediate token response is no longer useful after its next
+      // hop fails. Keep only `root` intact for fetchWithRetry's fallback.
+      if (current !== root) await current.body?.cancel().catch(() => {})
+      throw error
+    }
     hopped = true
 
     // 토큰 URL이 404면 원본을 한 번 더 시도 (홉이 세션을 세팅했을 수 있음)
     if (next.status === 404) {
-      return await fetchOnce(originalUrl, headers, timeout)
+      try {
+        const fallback = await fetchOnce(originalUrl, headers, timeout)
+        await next.body?.cancel().catch(() => {})
+        if (current !== root) await current.body?.cancel().catch(() => {})
+        return await finishWith(fallback)
+      } catch (error) {
+        await next.body?.cancel().catch(() => {})
+        if (current !== root) await current.body?.cancel().catch(() => {})
+        throw error
+      }
     }
 
+    // A successful hop replaces only the previous intermediate. The root is
+    // retained until a final usable response exists, so outer fallback never
+    // receives a cancelled body.
+    if (current !== root) await current.body?.cancel().catch(() => {})
     current = next
   }
 
-  return current
+  return await finishWith(current)
 }

--- a/src/lib/law-antibot.ts
+++ b/src/lib/law-antibot.ts
@@ -13,6 +13,10 @@
  * 원본 재시도 성공" 경로는 제한적이다. 주 경로는 토큰 URL 직접 파싱이다.
  */
 
+import { readResponseText } from "./response-body.js"
+import { ExecutionLimitError } from "./execution-limits.js"
+import { combineAbortSignals, getRequestSignal, requestContext, throwIfRequestCancelled } from "./session-state.js"
+
 /**
  * 안티봇 JS의 두 난독화 패턴에서 리다이렉트 경로를 복원한다.
  *
@@ -41,10 +45,12 @@ export function parseAntibotUrl(html: string): string | null {
 
 /** timeout이 걸린 단발 fetch */
 async function fetchOnce(url: string, headers: Headers, timeout: number): Promise<Response> {
+  throwIfRequestCancelled()
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeout)
   try {
-    return await fetch(url, { headers, signal: controller.signal })
+    requestContext.getStore()?.budget?.consumeUpstreamRequest()
+    return await fetch(url, { headers, signal: combineAbortSignals(controller.signal, getRequestSignal()) })
   } finally {
     clearTimeout(timeoutId)
   }
@@ -67,8 +73,9 @@ export async function followLawAntibot(
   for (let hop = 0; hop < maxHops; hop++) {
     let text: string
     try {
-      text = await current.clone().text()
-    } catch {
+      text = await readResponseText(current.clone())
+    } catch (error) {
+      if (error instanceof ExecutionLimitError || getRequestSignal()?.aborted) throw error
       return hopped ? current : null
     }
 

--- a/src/lib/response-body.ts
+++ b/src/lib/response-body.ts
@@ -1,0 +1,113 @@
+/** Bounded, cancellable readers for upstream Fetch responses. */
+
+import { getRequestSignal, requestCancelledError, requestContext, throwIfRequestCancelled } from "./session-state.js"
+
+function contentLength(response: Response): number | undefined {
+  const raw = response.headers.get("content-length")
+  if (!raw || !/^(?:0|[1-9]\d*)$/.test(raw)) return undefined
+  const value = Number(raw)
+  return Number.isSafeInteger(value) ? value : undefined
+}
+
+async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  try {
+    await reader.cancel()
+  } catch {
+    // The underlying fetch may already have closed the stream.
+  }
+}
+
+async function readChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal | undefined,
+): ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]> {
+  if (!signal) return reader.read()
+  if (signal.aborted) {
+    await cancelReader(reader)
+    throw requestCancelledError(signal.reason)
+  }
+
+  return new Promise<Awaited<ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>>>((resolve, reject) => {
+    const onAbort = () => {
+      void cancelReader(reader)
+      reject(requestCancelledError(signal.reason))
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+    reader.read().then(
+      value => {
+        signal.removeEventListener("abort", onAbort)
+        resolve(value)
+      },
+      error => {
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      },
+    )
+  })
+}
+
+/**
+ * Consume one upstream body while enforcing the request context's byte
+ * budgets.  `Response.text()` and `arrayBuffer()` provide no size hook, so
+ * using a reader is what lets cancellation and limits stop work in flight.
+ */
+export async function readResponseBytes(response: Response): Promise<Uint8Array> {
+  throwIfRequestCancelled()
+  const budget = requestContext.getStore()?.budget
+  const declaredSize = contentLength(response)
+  if (budget && declaredSize !== undefined) {
+    try {
+      budget.ensureResponseBodySize(declaredSize)
+    } catch (error) {
+      await response.body?.cancel().catch(() => {})
+      throw error
+    }
+  }
+
+  if (!response.body) return new Uint8Array()
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let length = 0
+  try {
+    while (true) {
+      const { done, value } = await readChunk(reader, getRequestSignal())
+      if (done) break
+      if (!value) continue
+
+      length += value.byteLength
+      if (budget) {
+        try {
+          budget.ensureResponseBodySize(length)
+          budget.consumeUpstreamBody(value.byteLength)
+        } catch (error) {
+          await cancelReader(reader)
+          throw error
+        }
+      }
+      chunks.push(value)
+    }
+  } catch (error) {
+    await cancelReader(reader)
+    throw error
+  } finally {
+    reader.releaseLock()
+  }
+
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+export async function readResponseText(response: Response): Promise<string> {
+  return new TextDecoder().decode(await readResponseBytes(response))
+}
+
+export async function readResponseArrayBuffer(response: Response): Promise<ArrayBuffer> {
+  const bytes = await readResponseBytes(response)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}

--- a/src/lib/session-state.ts
+++ b/src/lib/session-state.ts
@@ -6,9 +6,67 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks"
+import type { RequestExecutionBudget } from "./execution-limits.js"
 
 export interface RequestContext {
   apiKey?: string
+  /** HTTP disconnect signal, optionally combined with one MCP item's cancellation signal. */
+  signal?: AbortSignal
+  /** Shared by all tools in one outer HTTP request (including a JSON-RPC batch). */
+  budget?: RequestExecutionBudget
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>()
+
+/** A consistent cancellation error that callers can recognise without leaking transport details. */
+export function requestCancelledError(reason?: unknown): Error {
+  if (reason instanceof Error) return reason
+  const error = new Error(reason ? `Request cancelled: ${String(reason)}` : "Request cancelled.")
+  error.name = "AbortError"
+  return error
+}
+
+/**
+ * Combine signals without making a cancelled MCP item poison its sibling
+ * batch items.  The caller supplies only its own item signal; the shared
+ * request context contains the connection-level signal.
+ */
+export function combineAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const active = signals.filter((signal): signal is AbortSignal => Boolean(signal))
+  if (active.length === 0) return undefined
+  if (active.length === 1) return active[0]
+
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(active)
+  }
+
+  const controller = new AbortController()
+  const abort = (signal: AbortSignal) => controller.abort(signal.reason)
+  for (const signal of active) {
+    if (signal.aborted) {
+      abort(signal)
+      break
+    }
+    signal.addEventListener("abort", () => abort(signal), { once: true })
+  }
+  return controller.signal
+}
+
+/** Run work with the current request values retained and an additional item-scoped signal. */
+export function runWithRequestContext<T>(
+  values: Partial<RequestContext>,
+  work: () => T,
+): T {
+  const current = requestContext.getStore()
+  const signal = combineAbortSignals(current?.signal, values.signal)
+  return requestContext.run({ ...current, ...values, signal }, work)
+}
+
+export function getRequestSignal(): AbortSignal | undefined {
+  return requestContext.getStore()?.signal
+}
+
+export function throwIfRequestCancelled(): void {
+  const signal = getRequestSignal()
+  if (signal?.aborted) throw requestCancelledError(signal.reason)
+}

--- a/src/server/http-config.test.ts
+++ b/src/server/http-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { exceedsBatchLimit } from "./http-server.js"
+import { parseHttpPort, readHttpServerConfig } from "./http-config.js"
+
+describe("HTTP security configuration", () => {
+  it("defaults to loopback without trusting forwarded headers", () => {
+    const config = readHttpServerConfig({})
+    expect(config.host).toBe("127.0.0.1")
+    expect(config.trustProxy).toBe(false)
+    expect(config.maxBatchCalls).toBe(20)
+    expect(config.rateLimitRpm).toBe(60)
+  })
+
+  it("requires explicit authentication or override for non-loopback exposure", () => {
+    expect(() => readHttpServerConfig({ MCP_HTTP_HOST: "0.0.0.0" })).toThrow("MCP_HTTP_HOST is non-loopback")
+    expect(() => readHttpServerConfig({ MCP_HTTP_HOST: "0.0.0.0", MCP_AUTH_TOKEN: "   " })).toThrow("MCP_HTTP_HOST is non-loopback")
+    expect(readHttpServerConfig({ MCP_HTTP_HOST: "0.0.0.0", MCP_AUTH_TOKEN: "secret" }).host).toBe("0.0.0.0")
+    expect(readHttpServerConfig({ MCP_HTTP_HOST: "0.0.0.0", MCP_ALLOW_UNAUTHENTICATED_REMOTE: "1" }).allowUnauthenticatedRemote).toBe(true)
+  })
+
+  it("accepts only explicit numeric proxy hops", () => {
+    expect(readHttpServerConfig({ TRUST_PROXY: "1" }).trustProxy).toBe(1)
+    expect(() => readHttpServerConfig({ TRUST_PROXY: "true" })).toThrow("TRUST_PROXY must be an integer")
+  })
+
+  it("keeps the batch cap active when per-IP RPM limiting is disabled", () => {
+    const config = readHttpServerConfig({ RATE_LIMIT_RPM: "0", MCP_MAX_BATCH_CALLS: "2" })
+    const body = Array.from({ length: 3 }, () => ({ method: "tools/call" }))
+    expect(config.rateLimitRpm).toBe(0)
+    expect(exceedsBatchLimit(body, config.maxBatchCalls)).toBe(true)
+  })
+
+  it("fails startup configuration for invalid numeric limits", () => {
+    expect(() => readHttpServerConfig({ RATE_LIMIT_RPM: "nope" })).toThrow("RATE_LIMIT_RPM must be an integer")
+    expect(() => readHttpServerConfig({ MCP_MAX_BATCH_CALLS: "0" })).toThrow("MCP_MAX_BATCH_CALLS must be an integer")
+    expect(() => readHttpServerConfig({ MCP_MAX_BODY_BYTES: "NaN" })).toThrow("MCP_MAX_BODY_BYTES must be an integer")
+  })
+
+  it("validates the HTTP port as a whole number", () => {
+    expect(parseHttpPort(undefined, { PORT: "8123" })).toBe(8123)
+    expect(() => parseHttpPort(undefined, { PORT: "8123oops" })).toThrow("PORT must be an integer")
+  })
+})

--- a/src/server/http-config.ts
+++ b/src/server/http-config.ts
@@ -1,0 +1,93 @@
+/** Validated HTTP security configuration, kept separate so startup is testable. */
+
+import { parseIntegerLimit, readExecutionLimits, type ExecutionLimits } from "../lib/execution-limits.js"
+
+const DEFAULT_BODY_LIMIT_BYTES = 100 * 1024
+const MAX_BODY_LIMIT_BYTES = 10 * 1024 * 1024
+
+export interface HttpServerConfig {
+  host: string
+  trustProxy: number | false
+  authToken: string
+  allowUnauthenticatedRemote: boolean
+  bodyLimitBytes: number
+  rateLimitRpm: number
+  maxBatchCalls: number
+  fallbackRpm: number
+  executionLimits: ExecutionLimits
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase()
+  return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+}
+
+function parseRemoteUnauthenticatedOverride(raw: string | undefined): boolean {
+  if (raw === undefined || raw === "0") return false
+  if (raw === "1") return true
+  throw new Error("MCP_ALLOW_UNAUTHENTICATED_REMOTE must be 0 or 1.")
+}
+
+/** Only explicit, bounded hop counts are safe to infer from X-Forwarded-For. */
+function parseTrustProxy(raw: string | undefined): number | false {
+  if (raw === undefined || raw === "false" || raw === "0") return false
+  return parseIntegerLimit("TRUST_PROXY", raw, 0, 1, 10)
+}
+
+/**
+ * MCP_MAX_BODY_BYTES is the current numeric setting.  Accept the existing
+ * MCP_BODY_LIMIT spelling as a compatibility bridge, but validate it here
+ * rather than delegating malformed text to Express at request time.
+ */
+function parseBodyLimit(env: NodeJS.ProcessEnv): number {
+  if (env.MCP_MAX_BODY_BYTES !== undefined) {
+    return parseIntegerLimit("MCP_MAX_BODY_BYTES", env.MCP_MAX_BODY_BYTES, DEFAULT_BODY_LIMIT_BYTES, 1_024, MAX_BODY_LIMIT_BYTES)
+  }
+  const legacy = env.MCP_BODY_LIMIT
+  if (legacy === undefined) return DEFAULT_BODY_LIMIT_BYTES
+
+  const match = legacy.match(/^(\d+)(b|kb|mb)?$/i)
+  if (!match) {
+    throw new Error(`MCP_BODY_LIMIT must be a size from 1024 to ${MAX_BODY_LIMIT_BYTES} bytes (for example 100kb).`)
+  }
+  const multiplier = match[2]?.toLowerCase() === "mb" ? 1024 * 1024
+    : match[2]?.toLowerCase() === "kb" ? 1024
+      : 1
+  const value = Number(match[1]) * multiplier
+  if (!Number.isSafeInteger(value) || value < 1_024 || value > MAX_BODY_LIMIT_BYTES) {
+    throw new Error(`MCP_BODY_LIMIT must be a size from 1024 to ${MAX_BODY_LIMIT_BYTES} bytes (for example 100kb).`)
+  }
+  return value
+}
+
+export function parseHttpPort(raw: string | undefined, env: NodeJS.ProcessEnv = process.env): number {
+  return parseIntegerLimit("PORT", raw ?? env.PORT, 8000, 1, 65_535)
+}
+
+export function readHttpServerConfig(env: NodeJS.ProcessEnv = process.env): HttpServerConfig {
+  const host = (env.MCP_HTTP_HOST ?? "127.0.0.1").trim()
+  if (!host || /\s/.test(host)) {
+    throw new Error("MCP_HTTP_HOST must be a non-empty host without whitespace.")
+  }
+
+  const authToken = env.MCP_AUTH_TOKEN ?? ""
+  const hasAuthToken = authToken.trim().length > 0
+  const allowUnauthenticatedRemote = parseRemoteUnauthenticatedOverride(env.MCP_ALLOW_UNAUTHENTICATED_REMOTE)
+  if (!isLoopbackHost(host) && !hasAuthToken && !allowUnauthenticatedRemote) {
+    throw new Error(
+      "MCP_HTTP_HOST is non-loopback. Set MCP_AUTH_TOKEN or explicitly set MCP_ALLOW_UNAUTHENTICATED_REMOTE=1.",
+    )
+  }
+
+  return {
+    host,
+    trustProxy: parseTrustProxy(env.TRUST_PROXY),
+    authToken,
+    allowUnauthenticatedRemote,
+    bodyLimitBytes: parseBodyLimit(env),
+    rateLimitRpm: parseIntegerLimit("RATE_LIMIT_RPM", env.RATE_LIMIT_RPM, 60, 0, 100_000),
+    maxBatchCalls: parseIntegerLimit("MCP_MAX_BATCH_CALLS", env.MCP_MAX_BATCH_CALLS, 20, 1, 100),
+    fallbackRpm: parseIntegerLimit("FALLBACK_RATE_LIMIT_RPM", env.FALLBACK_RATE_LIMIT_RPM, 120, 0, 100_000),
+    executionLimits: readExecutionLimits(env),
+  }
+}

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -11,9 +11,11 @@ import { timingSafeEqual } from "node:crypto"
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
 import { requestContext } from "../lib/session-state.js"
+import { RequestExecutionBudget, type ExecutionLimits } from "../lib/execution-limits.js"
 import { maskSensitiveUrl } from "../lib/fetch-with-retry.js"
 import { TOOL_COUNTS } from "../tool-registry.js"
 import { VERSION } from "../version.js"
+import { readHttpServerConfig } from "./http-config.js"
 
 /** 타이밍 공격 내성 문자열 비교 (길이가 달라도 throw하지 않음) */
 function safeEqual(a: string, b: string): boolean {
@@ -42,21 +44,29 @@ function scrubError(error: unknown): { message: string; stack?: string } {
   return { message: maskSensitiveUrl(String(error)) }
 }
 
-export async function startHTTPServer(createServer: () => Server, port: number) {
+/** Count executable calls in an already-parsed JSON-RPC envelope. */
+export function countToolCalls(body: unknown): number {
+  const messages = Array.isArray(body) ? body : [body]
+  return messages.filter(message =>
+    typeof message === "object" && message !== null && (message as { method?: unknown }).method === "tools/call",
+  ).length
+}
+
+export function exceedsBatchLimit(body: unknown, maxBatchCalls: number): boolean {
+  return countToolCalls(body) > maxBatchCalls
+}
+
+export async function startHTTPServer(
+  createServer: (executionLimits: ExecutionLimits) => Server,
+  port: number,
+) {
+  // Parse every security boundary before the listener is opened.  A bad value
+  // must fail startup, not degrade into NaN and disable a comparison later.
+  const config = readHttpServerConfig()
   const app = express()
-  // trust proxy: TRUST_PROXY 환경변수로 조정 (기본 '1' = 첫 프록시만 신뢰).
-  // 'true' 또는 'all'은 X-Forwarded-For 스푸핑으로 rate limit 우회 위험.
-  // Fly.io는 edge proxy 1단 → '1' 권장. 다단 프록시면 숫자 증가.
-  const trustProxyRaw = process.env.TRUST_PROXY ?? "1"
-  const trustProxy: number | boolean | string =
-    trustProxyRaw === "true" || trustProxyRaw === "all"
-      ? true
-      : trustProxyRaw === "false"
-      ? false
-      : /^\d+$/.test(trustProxyRaw)
-      ? parseInt(trustProxyRaw, 10)
-      : trustProxyRaw // CIDR/IP 리스트 패스스루
-  app.set("trust proxy", trustProxy)
+  // Direct deployments must not trust a spoofable X-Forwarded-For header.
+  // A reverse-proxy deployment opts in with a bounded numeric hop count.
+  app.set("trust proxy", config.trustProxy)
 
   // ACCESS_LOG=1 일 때만 요청 로그 — req.path만 기록 (쿼리스트링의 oc= API 키 유출 방지)
   if (process.env.ACCESS_LOG === "1") {
@@ -114,9 +124,13 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
   // ── 접근 인증 (MCP_AUTH_TOKEN 설정 시에만 활성) ────────────────────────────
   // 폐쇄망·사내망 배포처럼 서버 자체에 접근 통제가 필요한 환경에서 설정한다.
   // 미설정이면 기존처럼 공개 동작 (법제처 API 키는 인가 수단이 아니다).
-  const authToken = process.env.MCP_AUTH_TOKEN || ""
+  const authToken = config.authToken
   if (!authToken) {
-    console.error("⚠️  MCP_AUTH_TOKEN 미설정 — /mcp 엔드포인트에 접근 인증이 없습니다. 폐쇄망/사내 배포에서는 반드시 설정하세요.")
+    if (config.allowUnauthenticatedRemote) {
+      console.error("⚠️  MCP_ALLOW_UNAUTHENTICATED_REMOTE=1 — non-loopback /mcp is intentionally unauthenticated.")
+    } else {
+      console.error("ℹ️  MCP_AUTH_TOKEN 미설정 — loopback HTTP only. Remote exposure requires MCP_AUTH_TOKEN or an explicit override.")
+    }
   }
   app.use((req, res, next) => {
     if (!authToken) return next()
@@ -138,53 +152,56 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
     next()
   })
 
-  app.use(express.json({ limit: process.env.MCP_BODY_LIMIT || "100kb" }))
+  app.use(express.json({ limit: config.bodyLimitBytes }))
 
   // Rate Limiting (RATE_LIMIT_RPM 환경변수, 기본: 60 req/min per IP)
-  const rateLimitRpm = parseInt(process.env.RATE_LIMIT_RPM || "60", 10)
+  const rateLimitRpm = config.rateLimitRpm
   const rateBuckets = new Map<string, { count: number; resetAt: number }>()
 
   // 단일 POST에 담을 수 있는 tools/call 상한. JSON-RPC 배치는 배열의 요청을
   // 전부 디스패치하므로(SDK 확인), 카운트 없이 두면 한 요청으로 rate limit·폴백
   // 쿼터를 배수만큼 우회할 수 있다. 배치 크기를 제한해 증폭을 원천 차단한다.
-  const maxBatchCalls = parseInt(process.env.MCP_MAX_BATCH_CALLS || "20", 10)
+  const maxBatchCalls = config.maxBatchCalls
+
+  // Batch work is bounded whether or not the optional per-IP rate limiter is
+  // enabled.  Otherwise RATE_LIMIT_RPM=0 accidentally turns off this guard.
+  app.use((req, res, next) => {
+    if (req.path === "/health" || req.path === "/") return next()
+
+    // 핸드셰이크(initialize)·도구목록(tools/list)·알림은 rate limit 제외.
+    // 이들이 429를 맞으면 클라이언트가 도구 목록을 못 받아 "도구 못 찾음"이 된다.
+    // claude.ai 커넥터는 소수 egress IP로 트래픽이 몰려 IP 버킷을 공유하므로,
+    // 비용 소모 요청(tools/call)에만 게이트한다. (v4.6.2 폴백 게이트와 동일 원칙)
+    // 배치는 tools/call '개수'만큼 카운트한다 (요청당 1회가 아님 — 배치 증폭 방지).
+    const callCount = countToolCalls(req.body)
+    if (callCount === 0) return next()
+
+    if (exceedsBatchLimit(req.body, maxBatchCalls)) {
+      res.status(429).json({ error: `Too many tool calls in one request (max ${maxBatchCalls}).` })
+      return
+    }
+
+    if (rateLimitRpm === 0) return next()
+
+    const ip = req.ip || req.socket.remoteAddress || "unknown"
+    const now = Date.now()
+    let bucket = rateBuckets.get(ip)
+
+    if (!bucket || now >= bucket.resetAt) {
+      bucket = { count: 0, resetAt: now + 60_000 }
+      rateBuckets.set(ip, bucket)
+    }
+
+    bucket.count += callCount
+
+    if (bucket.count > rateLimitRpm) {
+      res.status(429).json({ error: "Too many requests. Try again later." })
+      return
+    }
+    next()
+  })
 
   if (rateLimitRpm > 0) {
-    app.use((req, res, next) => {
-      if (req.path === "/health" || req.path === "/") return next()
-
-      // 핸드셰이크(initialize)·도구목록(tools/list)·알림은 rate limit 제외.
-      // 이들이 429를 맞으면 클라이언트가 도구 목록을 못 받아 "도구 못 찾음"이 된다.
-      // claude.ai 커넥터는 소수 egress IP로 트래픽이 몰려 IP 버킷을 공유하므로,
-      // 비용 소모 요청(tools/call)에만 게이트한다. (v4.6.2 폴백 게이트와 동일 원칙)
-      // 배치는 tools/call '개수'만큼 카운트한다 (요청당 1회가 아님 — 배치 증폭 방지).
-      const msgs = Array.isArray(req.body) ? req.body : [req.body]
-      const callCount = msgs.filter(m => m?.method === "tools/call").length
-      if (callCount === 0) return next()
-
-      if (callCount > maxBatchCalls) {
-        res.status(429).json({ error: `Too many tool calls in one request (max ${maxBatchCalls}).` })
-        return
-      }
-
-      const ip = req.ip || req.socket.remoteAddress || "unknown"
-      const now = Date.now()
-      let bucket = rateBuckets.get(ip)
-
-      if (!bucket || now >= bucket.resetAt) {
-        bucket = { count: 0, resetAt: now + 60_000 }
-        rateBuckets.set(ip, bucket)
-      }
-
-      bucket.count += callCount
-
-      if (bucket.count > rateLimitRpm) {
-        res.status(429).json({ error: "Too many requests. Try again later." })
-        return
-      }
-      next()
-    })
-
     // 5분마다 만료된 버킷 정리
     setInterval(() => {
       const now = Date.now()
@@ -232,7 +249,7 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
 
   // 서버 LAW_OC 폴백 사용량 전역 상한 — 키 없는 분산 요청이 서버 키의 법제처 quota를
   // 소진시키는 것 방지 (IP당 limit만으로는 막을 수 없음). 0이면 폴백 비활성.
-  const fallbackRpm = parseInt(process.env.FALLBACK_RATE_LIMIT_RPM || "120", 10)
+  const fallbackRpm = config.fallbackRpm
   const fallbackBucket = { count: 0, resetAt: 0 }
   // n = 이 요청이 소모하는 tools/call 개수 (배치는 배열 길이만큼 서버 키를 쓴다)
   function fallbackAllowed(n: number): boolean {
@@ -268,8 +285,7 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
     // 자체 키 없는 요청은 서버 LAW_OC로 폴백 — 전역 상한 적용
     // initialize/tools/list 등 핸드셰이크는 법제처 쿼터를 안 쓰므로 tools/call만 게이트
     // (핸드셰이크까지 429로 막으면 claude.ai 커넥터가 도구 목록 자체를 못 싣는다)
-    const bodyMessages = Array.isArray(req.body) ? req.body : [req.body]
-    const fallbackCallCount = bodyMessages.filter((m) => m?.method === "tools/call").length
+    const fallbackCallCount = countToolCalls(req.body)
     if (!apiKey && fallbackCallCount > 0 && !fallbackAllowed(fallbackCallCount)) {
       res.status(429).json({
         jsonrpc: "2.0",
@@ -283,14 +299,24 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
     let transport: StreamableHTTPServerTransport | undefined
 
     try {
-      server = createServer()
+      server = createServer(config.executionLimits)
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,  // ← stateless 모드
         enableJsonResponse: true,
       })
 
+      // Disconnecting the HTTP client must stop its upstream work.  This is
+      // deliberately separate from MCP's item cancellation signal: sibling
+      // batch items share a budget but retain separate cancellation signals.
+      const connectionAbort = new AbortController()
+      const abortConnection = () => {
+        if (!connectionAbort.signal.aborted) connectionAbort.abort("HTTP client disconnected")
+      }
+      req.once("aborted", abortConnection)
+
       // 요청 종료 시 리소스 정리
       res.on("close", () => {
+        if (!res.writableEnded) abortConnection()
         try { transport?.close() } catch { /* ignore */ }
         server?.close().catch(() => {})
       })
@@ -298,7 +324,11 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
       await server.connect(transport)
 
       // ALS로 요청 단위 API 키 격리 (동시 요청 안전)
-      await requestContext.run({ apiKey }, async () => {
+      await requestContext.run({
+        apiKey,
+        signal: connectionAbort.signal,
+        budget: new RequestExecutionBudget(config.executionLimits),
+      }, async () => {
         await transport!.handleRequest(req, res, req.body)
       })
     } catch (error) {
@@ -353,11 +383,12 @@ export async function startHTTPServer(createServer: () => Server, port: number) 
     })
   })
 
-  // 서버 시작 (0.0.0.0으로 바인딩하여 외부 접속 허용)
-  const expressServer = app.listen(port, "0.0.0.0", () => {
+  // 서버 시작.  Loopback is the safe default; remote exposure is an explicit
+  // MCP_HTTP_HOST configuration validated above.
+  const expressServer = app.listen(port, config.host, () => {
     console.error(`✓ Korean Law MCP server (HTTP stateless) listening on port ${port}`)
-    console.error(`✓ MCP endpoint: http://0.0.0.0:${port}/mcp`)
-    console.error(`✓ Health check: http://0.0.0.0:${port}/health`)
+    console.error(`✓ MCP endpoint: http://${config.host}:${port}/mcp`)
+    console.error(`✓ Health check: http://${config.host}:${port}/health`)
   })
 
   // 종료 처리 — in-flight 요청 완료 대기 (최대 10초), 이후 강제 종료

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -9,6 +9,9 @@ import { z } from "zod"
 import type { LawApiClient } from "./lib/api-client.js"
 import type { McpTool } from "./lib/types.js"
 import { formatToolError } from "./lib/errors.js"
+import { RequestExecutionBudget, readExecutionLimits, type ExecutionLimits } from "./lib/execution-limits.js"
+import { truncateResponse } from "./lib/schemas.js"
+import { getRequestSignal, requestContext, runWithRequestContext, throwIfRequestCancelled } from "./lib/session-state.js"
 import { discoverTools, DiscoverToolsSchema, executeTool, ExecuteToolSchema, setAllToolsRef } from "./tools/meta-tools.js"
 import { searchDecisions, SearchDecisionsSchema, getDecisionText, GetDecisionTextSchema } from "./tools/unified-decisions.js"
 
@@ -804,7 +807,11 @@ const exposedTools = allTools.filter(t => V3_EXPOSED.has(t.name))
 /** 노출/전체 도구 수 — 헬스체크 등 표기용 파생값 (하드코딩 금지) */
 export const TOOL_COUNTS = { exposed: exposedTools.length, total: allTools.length }
 
-export function registerTools(server: Server, apiClient: LawApiClient) {
+export function registerTools(
+  server: Server,
+  apiClient: LawApiClient,
+  executionLimits: ExecutionLimits = readExecutionLimits(),
+) {
   // ListTools 핸들러
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: exposedTools.map(tool => ({
@@ -821,30 +828,52 @@ export function registerTools(server: Server, apiClient: LawApiClient) {
   }))
 
   // CallTool 핸들러 — 전체 도구 실행 가능 (execute_tool 프록시 지원)
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    // The HTTP entrypoint puts one budget in AsyncLocalStorage for the whole
+    // JSON-RPC envelope.  A stdio request has no outer context, so create one
+    // here.  `extra.signal` is item-specific: cancelling one batch item does
+    // not cancel siblings that only share the budget.
+    const budget = requestContext.getStore()?.budget ?? new RequestExecutionBudget(executionLimits)
+    return runWithRequestContext({ budget, signal: extra.signal }, async () => {
+      const { name, arguments: args } = request.params
+      const tool = toolMap.get(name)
+      if (!tool) {
+        return {
+          content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+          isError: true,
+        }
+      }
 
-    const tool = toolMap.get(name)
-    if (!tool) {
-      return {
-        content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
-        isError: true
+      try {
+        throwIfRequestCancelled()
+        const input = tool.schema.parse(args)
+        const result = await tool.handler(apiClient, input)
+        throwIfRequestCancelled()
+        const text = truncateResponse(
+          result.content.map(content => content.text).join("\n"),
+          executionLimits.maxToolResponseChars,
+        )
+        return {
+          content: [{ type: "text" as const, text }],
+          isError: result.isError,
+        }
+      } catch (error) {
+        // Do not turn MCP or connection cancellation into a normal tool
+        // result.  The SDK will suppress the response for its cancelled item;
+        // rethrowing also keeps upstream cancellation visible to the transport.
+        if (getRequestSignal()?.aborted) throw error
+        const errResult = formatToolError(error, name)
+        return {
+          content: [{
+            type: "text" as const,
+            text: truncateResponse(
+              errResult.content.map(content => content.text).join("\n"),
+              executionLimits.maxToolResponseChars,
+            ),
+          }],
+          isError: true,
+        }
       }
-    }
-
-    try {
-      const input = tool.schema.parse(args)
-      const result = await tool.handler(apiClient, input)
-      return {
-        content: result.content.map(c => ({ type: "text" as const, text: c.text })),
-        isError: result.isError
-      }
-    } catch (error) {
-      const errResult = formatToolError(error, name)
-      return {
-        content: errResult.content.map(c => ({ type: "text" as const, text: c.text })),
-        isError: true
-      }
-    }
+    })
   })
 }

--- a/src/tools/annex.ts
+++ b/src/tools/annex.ts
@@ -5,6 +5,7 @@
 import { z } from "zod"
 import type { LawApiClient } from "../lib/api-client.js"
 import { fetchWithRetry } from "../lib/fetch-with-retry.js"
+import { readResponseArrayBuffer } from "../lib/response-body.js"
 import { parseAnnexFile } from "../lib/annex-file-parser.js"
 import { truncateResponse, MAX_RESPONSE_SIZE } from "../lib/schemas.js"
 import { formatToolError, notFoundResponse } from "../lib/errors.js"
@@ -266,7 +267,7 @@ async function extractAnnexContent(
     }
   }
 
-  const buffer = await response.arrayBuffer()
+  const buffer = await readResponseArrayBuffer(response)
   const result = await parseAnnexFile(buffer)
 
   if (result.fileType === "pdf" && result.isImageBased) {

--- a/src/tools/batch-articles.limits.test.ts
+++ b/src/tools/batch-articles.limits.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import {
+  GetBatchArticlesSchema,
+  MAX_ARTICLES_PER_LAW,
+  MAX_BATCH_ARTICLES,
+  MAX_BATCH_LAWS,
+} from "./batch-articles.js"
+
+describe("get_batch_articles execution boundaries", () => {
+  it("permits a documented bounded multi-law request", () => {
+    const parsed = GetBatchArticlesSchema.parse({
+      laws: Array.from({ length: 2 }, (_, index) => ({
+        mst: String(index + 1),
+        articles: ["제1조", "제2조"],
+      })),
+    })
+    expect(parsed.laws).toHaveLength(2)
+  })
+
+  it("rejects unbounded law fan-out before any API or cache work", () => {
+    expect(() => GetBatchArticlesSchema.parse({
+      laws: Array.from({ length: MAX_BATCH_LAWS + 1 }, (_, index) => ({ mst: String(index), articles: ["제1조"] })),
+    })).toThrow()
+  })
+
+  it("bounds nested articles and the total request article count", () => {
+    expect(() => GetBatchArticlesSchema.parse({
+      mst: "1",
+      articles: Array.from({ length: MAX_ARTICLES_PER_LAW + 1 }, () => "제1조"),
+    })).toThrow()
+
+    expect(() => GetBatchArticlesSchema.parse({
+      laws: Array.from({ length: MAX_BATCH_LAWS }, (_, index) => ({
+        mst: String(index),
+        articles: Array.from({ length: 6 }, () => "제1조"),
+      })),
+    })).toThrow(`최대 ${MAX_BATCH_ARTICLES}개`)
+  })
+})

--- a/src/tools/batch-articles.ts
+++ b/src/tools/batch-articles.ts
@@ -11,11 +11,21 @@ import { formatArticleUnit } from "../lib/article-parser.js"
 import { truncateResponse } from "../lib/schemas.js"
 import type { ToolResponse } from "../lib/types.js"
 import { formatToolError } from "../lib/errors.js"
+import { throwIfRequestCancelled } from "../lib/session-state.js"
+
+/**
+ * One batch fetches a whole law per entry, so these are execution—not merely
+ * schema—limits.  They keep a valid outer MCP request from churning the
+ * shared cache or fanning out into hundreds of upstream reads.
+ */
+export const MAX_BATCH_LAWS = 20
+export const MAX_ARTICLES_PER_LAW = 50
+export const MAX_BATCH_ARTICLES = 100
 
 const LawEntrySchema = z.object({
   mst: z.string().optional().describe("법령일련번호"),
   lawId: z.string().optional().describe("법령ID"),
-  articles: z.array(z.string()).describe("조문 번호 배열 (예: ['제38조', '제39조'])"),
+  articles: z.array(z.string()).max(MAX_ARTICLES_PER_LAW).describe("조문 번호 배열 (예: ['제38조', '제39조'])"),
 })
 
 type LawEntry = z.infer<typeof LawEntrySchema>
@@ -23,14 +33,25 @@ type LawEntry = z.infer<typeof LawEntrySchema>
 export const GetBatchArticlesSchema = z.object({
   mst: z.string().optional().describe("법령일련번호 (단일 법령 조회 시)"),
   lawId: z.string().optional().describe("법령ID (단일 법령 조회 시)"),
-  articles: z.array(z.string()).optional().describe("조문 번호 배열 (단일 법령 조회 시, 예: ['제38조', '제39조'])"),
+  articles: z.array(z.string()).max(MAX_ARTICLES_PER_LAW).optional().describe("조문 번호 배열 (단일 법령 조회 시, 예: ['제38조', '제39조'])"),
   efYd: z.string().optional().describe("시행일자 (YYYYMMDD 형식)"),
   apiKey: z.string().optional().describe("법제처 Open API 인증키(OC). 사용자가 제공한 경우 전달"),
-  laws: z.array(LawEntrySchema).optional().describe(
+  laws: z.array(LawEntrySchema).max(MAX_BATCH_LAWS).optional().describe(
     "복수 법령 조문 일괄 조회 (예: [{mst:'123', articles:['제1조','제2조']}, {lawId:'456', articles:['제3조']}])"
   ),
 }).refine(data => data.laws || data.mst || data.lawId, {
   message: "laws 배열 또는 mst/lawId 중 하나는 필수입니다"
+}).superRefine((data, ctx) => {
+  const totalArticles = data.laws
+    ? data.laws.reduce((total, law) => total + law.articles.length, 0)
+    : data.articles?.length ?? 0
+  if (totalArticles > MAX_BATCH_ARTICLES) {
+    ctx.addIssue({
+      code: "custom",
+      message: `조문은 한 번에 최대 ${MAX_BATCH_ARTICLES}개까지 조회할 수 있습니다.`,
+      path: data.laws ? ["laws"] : ["articles"],
+    })
+  }
 })
 
 export type GetBatchArticlesInput = z.infer<typeof GetBatchArticlesSchema>
@@ -71,6 +92,7 @@ async function fetchArticlesForLaw(
   efYd?: string,
   apiKey?: string
 ): Promise<FetchResult> {
+  throwIfRequestCancelled()
   const cacheKey = `batch:${lawReq.mst || lawReq.lawId}:full:${efYd || 'current'}`
   let fullLawData: LawResponse
 
@@ -99,6 +121,7 @@ async function fetchArticlesForLaw(
   // 조문 번호를 JO 코드로 변환
   const joCodes = new Set<string>()
   for (const article of lawReq.articles) {
+    throwIfRequestCancelled()
     try {
       const joCode = buildJO(article)
       joCodes.add(joCode)
@@ -125,6 +148,7 @@ async function fetchArticlesForLaw(
   let foundCount = 0
 
   for (const unit of articleUnits) {
+    throwIfRequestCancelled()
     if (unit.조문여부 !== "조문") continue
 
     const joNum = unit.조문번호 || ""
@@ -156,6 +180,7 @@ export async function getBatchArticles(
   input: GetBatchArticlesInput
 ): Promise<ToolResponse> {
   try {
+    throwIfRequestCancelled()
     // 입력 정규화: laws 배열 또는 단일 법령 -> 통일된 배열
     let lawRequests: LawEntry[]
     if (input.laws && input.laws.length > 0) {
@@ -175,6 +200,7 @@ export async function getBatchArticles(
     // 사전 검증: 유효한 요청만 필터링
     const validRequests: { index: number; lawReq: LawEntry }[] = []
     for (let i = 0; i < lawRequests.length; i++) {
+      throwIfRequestCancelled()
       const lawReq = lawRequests[i]
       if (!lawReq.articles || lawReq.articles.length === 0) {
         errors.push(`${lawReq.mst || lawReq.lawId}: articles 배열이 비어 있습니다.`)
@@ -192,6 +218,7 @@ export async function getBatchArticles(
     const fetchResults: { index: number; result?: FetchResult; error?: string }[] = []
 
     for (let i = 0; i < validRequests.length; i += CONCURRENCY) {
+      throwIfRequestCancelled()
       const chunk = validRequests.slice(i, i + CONCURRENCY)
       const settled = await Promise.allSettled(
         chunk.map(async ({ index, lawReq }) => {

--- a/src/tools/chains.ts
+++ b/src/tools/chains.ts
@@ -40,6 +40,7 @@ import {
   type StructuredPrecedentSearchResult,
 } from "./precedent-search-core.js"
 import { fetchPrecedentEvidence, validatePrecedentSearchResult } from "./precedent-evidence.js"
+import { getRequestSignal, throwIfRequestCancelled } from "../lib/session-state.js"
 
 // ========================================
 // Types
@@ -86,10 +87,12 @@ async function safeSearchPrecedentsStructured(
   context: PrecedentSearchContext = {}
 ): Promise<{ result: StructuredPrecedentSearchResult; error?: CallResult }> {
   try {
+    throwIfRequestCancelled()
     return {
       result: await searchPrecedentsStructured(apiClient, args, context),
     }
   } catch (error) {
+    if (getRequestSignal()?.aborted) throw error
     return {
       result: emptyStructuredPrecedentResult(args),
       error: errorCallResult(error, "search_precedents"),
@@ -104,9 +107,12 @@ async function callTool(
   input: Record<string, unknown>
 ): Promise<CallResult> {
   try {
+    throwIfRequestCancelled()
     const result = await handler(apiClient, input)
+    throwIfRequestCancelled()
     return { text: result.content?.[0]?.text || "", isError: !!result.isError }
   } catch (e) {
+    if (getRequestSignal()?.aborted) throw e
     return { text: `오류: ${e instanceof Error ? e.message : String(e)}`, isError: true }
   }
 }
@@ -116,13 +122,16 @@ async function callAiLaw(
   input: SearchAiLawInput
 ): Promise<CallResult> {
   try {
+    throwIfRequestCancelled()
     const result = await searchAiLawStructured(apiClient, input)
+    throwIfRequestCancelled()
     return {
       text: result.response.content?.[0]?.text || "",
       isError: !!result.response.isError,
       aiLawArticles: result.articleSignals,
     }
   } catch (e) {
+    if (getRequestSignal()?.aborted) throw e
     return { text: `오류: ${e instanceof Error ? e.message : String(e)}`, isError: true }
   }
 }
@@ -812,6 +821,7 @@ export async function chainDocumentReview(
   input: z.infer<typeof chainDocumentReviewSchema>
 ): Promise<ToolResponse> {
   try {
+    throwIfRequestCancelled()
     const parts = [`═══ 문서 종합 검토 ═══`]
 
     // Step 1: analyze_document 로 리스크 분석
@@ -849,6 +859,7 @@ export async function chainDocumentReview(
         validateResult: validation => validatePrecedentSearchResult(apiClient, validation, { apiKey: input.apiKey }),
       }))
     )
+    throwIfRequestCancelled()
     const precedentResults = precedentSearches.map(search => search.result)
 
     // AI 법령 검색은 상위 3개 힌트로 병렬 실행
@@ -856,6 +867,7 @@ export async function chainDocumentReview(
     const lawResults = await Promise.all(
       lawHints.map(hint => callTool(searchAiLaw, apiClient, { query: hint, display: 3, apiKey: input.apiKey }))
     )
+    throwIfRequestCancelled()
 
     // 판례 결과 합산
     const precTexts: string[] = []

--- a/src/tools/legal-research.ts
+++ b/src/tools/legal-research.ts
@@ -22,6 +22,7 @@ import {
   chainProcedureDetail, chainProcedureDetailSchema,
   chainDocumentReview,
 } from "./chains.js"
+import { throwIfRequestCancelled } from "../lib/session-state.js"
 
 const TASK_VALUES = new Set([
   "full_research", "law_system", "action_basis", "dispute_prep",
@@ -126,6 +127,7 @@ export async function legalResearch(
   apiClient: LawApiClient,
   input: LegalResearchInput
 ): Promise<ToolResponse> {
+  throwIfRequestCancelled()
   const task = input.task ?? "full_research"
 
   if (task === "document_review") {

--- a/src/tools/precedents.ts
+++ b/src/tools/precedents.ts
@@ -4,6 +4,7 @@ import { cleanHtml } from "../lib/article-parser.js"
 import { truncateResponse } from "../lib/schemas.js"
 import { formatToolError } from "../lib/errors.js"
 import { fetchWithRetry } from "../lib/fetch-with-retry.js"
+import { readResponseText } from "../lib/response-body.js"
 import {
   type ExternalHttpsProxyConfig,
   getExternalHttpsProxyConfig,
@@ -261,7 +262,7 @@ function isMissingPrecedentJson(data: unknown): boolean {
 }
 
 async function fetchText(response: Response, context: string): Promise<string> {
-  const text = await response.text()
+  const text = await readResponseText(response)
   if (!response.ok) {
     throw new Error(`${context} failed with HTTP ${response.status}`)
   }
@@ -515,4 +516,3 @@ export async function getPrecedentText(
     return formatToolError(error, "get_precedent_text")
   }
 }
-


### PR DESCRIPTION
Harden MCP request ownership with shared work budgets, item-scoped cancellation, bounded response reads, and fail-closed HTTP defaults. This also bounds batch expansion, removes proxy/rate-limit fail-open behavior, adds clean verified package construction and trusted publishing, omits optional native runtime dependencies on supported installs, and adds contributor guidance.

Validation: typecheck, 174 tests, clean build, 220-file package verification, Knip, production audit with zero findings, pruned annex-PDF smoke test, diff check, and independent Gestell PASS. The npm registry trusted-publisher mapping remains an explicit external prerequisite documented in the repository.

Closes #80
Closes #81
Closes #82
Closes #83
Closes #84