### PR TITLE
fix(readme): 더 이상 표시되지 않는 Star History 차트 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,11 +976,11 @@ v4.4.0에서 노출 도구를 통폐합했습니다 (컨텍스트 52% 감축). �
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=chrisryugj%2Fkorean-law-mcp&type=timeline&legend=bottom-right">
+<a href="https://star-history.dera.page/#chrisryugj/korean-law-mcp&type=timeline&legend=bottom-right">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=chrisryugj/korean-law-mcp&type=timeline&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=chrisryugj/korean-law-mcp&type=timeline&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=chrisryugj/korean-law-mcp&type=timeline&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=chrisryugj/korean-law-mcp&type=timeline&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=chrisryugj/korean-law-mcp&type=timeline&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=chrisryugj/korean-law-mcp&type=timeline&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
README 하단의 Star History 차트가 현재 깨져 있습니다. GitHub stargazer API 제약으로 기존 star-history.com 차트가 로드되지 않아 저장소 활동 그래프가 보이지 않습니다. API 토큰이 필요 없는 대체 데이터 소스를 쓰는 star-history.dera.page로 이미지 주소를 전환해 차트를 복구합니다. 래핑 링크는 해시 기반 URL(https://star-history.dera.page/#chrisryugj/korean-law-mcp&type=timeline)로, /chart 엔드포인트는 /svg로 변경했고, 파라미터 값은 기존과 동일하게 유지했습니다.