### PR TITLE
fix: 분리시행 슬라이스 dedup 소실 + eflaw MST 단독 조회 빈 봉투 폴백

### DIFF
--- a/src/lib/api-client.eflaw-fallback.test.ts
+++ b/src/lib/api-client.eflaw-fallback.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { LawApiClient } from "./api-client.js"
+
+// 회귀 (2026-08-19 형사소송법 실측): lawService.do target=eflaw 단건 조회는 MST 단독
+// (efYd 미동반)으로 "현행이 아닌" 버전을 못 푼다 — 시행 예정판(MST 288579, 시행
+// 2026.10.2.)과 과거 연혁판(MST 280441, 시행 2026.6.24.) 모두 200 + "{}"로 온다.
+// 같은 MST를 target=law로 치면 그 버전 전문(부칙 포함)이 그대로 회수되므로
+// getLawText는 빈 봉투일 때 law 타깃으로 1회 폴백해야 한다. 이 갭은 2026.10.2.
+// 형소법 대개정(§215조의2 검사 직권 삭제 등)을 도구가 통째로 침묵하게 만든
+// 서면 사고 경로였다.
+
+const LAW_BODY = `{"법령": {"기본정보": {"법령명_한글": "형사소송법", "시행일자": 20261002}}}`
+
+const jsonRes = (body: string) =>
+  new Response(body, { status: 200, headers: { "content-type": "application/json" } })
+
+describe("getLawText — eflaw 빈 봉투 시 law 타깃 폴백", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("eflaw가 '{}'를 주면 target=law로 폴백해 그 MST 버전을 회수한다", async () => {
+    const urls: string[] = []
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      urls.push(String(url))
+      return String(url).includes("target=eflaw") ? jsonRes("{}") : jsonRes(LAW_BODY)
+    }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    const text = await client.getLawText({ mst: "288579" })
+
+    expect(text).toContain("기본정보")
+    expect(urls).toHaveLength(2)
+    expect(urls[0]).toContain("target=eflaw")
+    expect(urls[1]).toContain("target=law")
+    expect(urls[1]).toContain("MST=288579")
+  })
+
+  it("폴백 요청에 JO 파라미터를 유지한다 (조문 단건 조회 경로)", async () => {
+    const urls: string[] = []
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      urls.push(String(url))
+      return String(url).includes("target=eflaw") ? jsonRes("{}") : jsonRes(LAW_BODY)
+    }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    await client.getLawText({ mst: "288579", jo: "021502" })
+
+    expect(urls[1]).toContain("target=law")
+    expect(urls[1]).toContain("JO=021502")
+  })
+
+  it("eflaw가 정상 법령 노드를 주면 폴백하지 않는다", async () => {
+    let calls = 0
+    vi.stubGlobal("fetch", vi.fn(async () => { calls++; return jsonRes(LAW_BODY) }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    const text = await client.getLawText({ mst: "281865" })
+
+    expect(text).toContain("기본정보")
+    expect(calls).toBe(1)
+  })
+
+  it("MST 없는 조회(lawId)는 빈 봉투라도 폴백하지 않는다 (발동 조건 보수 유지)", async () => {
+    let calls = 0
+    vi.stubGlobal("fetch", vi.fn(async () => { calls++; return jsonRes("{}") }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    const text = await client.getLawText({ lawId: "1234" })
+
+    expect(text).toBe("{}")   // 상위 레이어(law-text.ts)가 NOT_FOUND로 표면화
+    expect(calls).toBe(1)
+  })
+
+  it("law 폴백도 빈 봉투면 원래 eflaw 응답을 그대로 반환한다", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes("{}")))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    const text = await client.getLawText({ mst: "99999999" })
+
+    expect(text).toBe("{}")   // NOT_FOUND 표면화는 상위 레이어 몫 — 여기서 추측 금지
+  })
+})

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -29,6 +29,20 @@ import { getLawApiBaseUrl } from "./law-url-config.js"
 
 const LAW_API_BASE = getLawApiBaseUrl()
 
+/**
+ * JSON 본문에 법령 노드가 실제로 있는지 — getLawText의 eflaw→law 폴백 판정 전용.
+ * 파싱 불가 본문은 true(폴백 안 함)로 두어, 형식이 다른 정상 응답을 폴백이
+ * 덮어쓰지 않게 한다 (폴백은 "확실히 빈 봉투"에만 발동).
+ */
+function hasLawNode(text: string): boolean {
+  try {
+    const json = JSON.parse(text)
+    return json !== null && typeof json === "object" && "법령" in json
+  } catch {
+    return true
+  }
+}
+
 export class LawApiClient {
   private defaultApiKey: string
 
@@ -159,6 +173,31 @@ export class LawApiClient {
     this.checkHtmlError(text, params.jo
       ? `법령 조문(${params.jo})을 찾을 수 없습니다. MST/lawId와 조문번호를 확인해주세요.`
       : "법령을 찾을 수 없습니다. MST 또는 법령명을 확인해주세요.")
+
+    // eflaw 단건 조회는 MST 단독(efYd 미동반)으로 "현행이 아닌" 버전을 못 푼다 —
+    // 시행 예정판·과거 연혁판 모두 200 + "{}"로 온다 (2026-08-19 형사소송법 실측:
+    // MST 288579 시행 2026.10.2.판, MST 280441 시행 2026.6.24.판 둘 다 빈 응답).
+    // MST는 버전 고유값이라 target=law로 치면 그 버전 전문(부칙 포함)이 그대로
+    // 회수되므로, 법령 노드가 빈 응답이면 law 타깃으로 1회 폴백한다.
+    if (params.mst && !hasLawNode(text)) {
+      const fbParams = new URLSearchParams({
+        target: "law",
+        OC: this.getApiKey(params.apiKey),
+        type: "JSON",
+      })
+      fbParams.append("MST", String(params.mst))
+      if (params.jo) fbParams.append("JO", String(params.jo))
+
+      const fbUrl = `${LAW_API_BASE}/lawService.do?${fbParams.toString()}`
+      const fbResponse = await fetchWithRetry(fbUrl, lookupRetryFor("law"))
+      await this.throwIfError(fbResponse, "getLawText")
+
+      const fbText = await this.readBody(fbResponse, "법령 조회")
+      this.checkHtmlError(fbText, params.jo
+        ? `법령 조문(${params.jo})을 찾을 수 없습니다. MST/lawId와 조문번호를 확인해주세요.`
+        : "법령을 찾을 수 없습니다. MST 또는 법령명을 확인해주세요.")
+      if (hasLawNode(fbText)) return fbText
+    }
 
     return text
   }

--- a/src/lib/historical-utils.test.ts
+++ b/src/lib/historical-utils.test.ts
@@ -82,4 +82,30 @@ describe("fetchHistoricalVersionsFull — 페이징 종료 판정", () => {
     expect(served).toEqual(["1", "2"])                   // 콤마 미파싱이면 1페이지에서 끊겨 "2" 없음
     expect(r.versions.map(v => v.mst)).toContain("800")  // 옛 본법 버전 도달
   })
+
+  // 회귀 (2026-08-19 형사소송법 실측): lsHistory는 분리시행 공포본을 같은 MST의
+  // 여러 행(시행일별)으로 내보낸다. 중복 제거 키가 MST 단독이면 시행일 내림차순
+  // 첫 행(미래 시행분)만 남아 이미 시행된 슬라이스가 사라지고, applicable_law의
+  // "현행" 탐색(efYd <= today)이 그 MST를 통째로 건너뛰어 직전 공포본을 현행으로
+  // 오판정한다 (MST 281865: 시행 20260701 슬라이스 소실 → 20260624판을 현행 반환).
+  it("분리시행(같은 MST·복수 시행일) 행을 슬라이스별로 모두 보존한다", async () => {
+    const page1 = pageHtml(3, [
+      row("형사소송법", 281865, "20271231"),  // 미래 시행분 (efdes 내림차순 첫 행)
+      row("형사소송법", 281865, "20260701"),  // 이미 시행된 슬라이스 — MST 단독 키면 소실
+      row("형사소송법", 280441, "20260624"),
+    ])
+    const client = {
+      fetchApi: async () => page1,
+    } as unknown as LawApiClient
+
+    const r = await fetchHistoricalVersionsFull(client, "형사소송법", undefined, 500)
+    expect(r.versions.map(v => `${v.mst}@${v.efYd}`)).toEqual([
+      "281865@20271231",
+      "281865@20260701",
+      "280441@20260624",
+    ])
+    // applicable_law의 현행 판정 재현: 오늘=20260819 기준 첫 매치가 20260701판이어야 한다
+    const current = r.versions.find(v => v.efYd && v.efYd <= "20260819")
+    expect(current?.efYd).toBe("20260701")
+  })
 })

--- a/src/lib/historical-utils.ts
+++ b/src/lib/historical-utils.ts
@@ -123,11 +123,17 @@ export async function fetchHistoricalVersionsFull(
     page++
   }
 
-  // 중복 제거 (MST 기준 — 페이징 경계 안전망)
+  // 중복 제거 (MST+시행일 쌍 기준 — 페이징 경계 안전망).
+  // lsHistory는 분리시행 공포본을 같은 MST의 여러 행으로 내보낸다
+  // (예: 형사소송법 MST 281865 = 시행 2026.7.1. + 2027.12.31.). MST 단독 키는
+  // 시행일 내림차순 첫 행(미래 시행분)만 남겨 이미 시행된 슬라이스가 사라지고,
+  // applicable_law가 시행 중 버전을 건너뛰어 직전 공포본을 "현행"으로 오판정한다
+  // (2026-08-19 실측: 20260701 시행분 누락 → 20260624판을 현행 반환).
   const seen = new Set<string>()
   const unique = allVersions.filter(v => {
-    if (seen.has(v.mst)) return false
-    seen.add(v.mst)
+    const key = `${v.mst}:${v.efYd}`
+    if (seen.has(key)) return false
+    seen.add(key)
     return true
   })
 

--- a/src/tools/applicable-law.staggered.test.ts
+++ b/src/tools/applicable-law.staggered.test.ts
@@ -150,6 +150,62 @@ describe("applicableLaw — 적용 버전 자신의 부칙 발췌 (laterVersions
   })
 })
 
+describe("applicableLaw — 분리시행 슬라이스 보존 + 시행 예정 개정 경고", () => {
+  beforeEach(() => lawCache.clear())
+
+  // 회귀 (2026-08-19 형사소송법 실측): ① 같은 MST가 분리시행으로 두 행(이미 시행분 +
+  // 미래 시행분)일 때 MST 단독 dedup이 이미 시행분을 지워 "현행"이 직전 공포본으로
+  // 밀렸다. ② 시행 예정 대개정(제21857호, 2026.10.2.)의 존재를 응답 어디서도 알리지
+  // 않아 현행 인용만 보고 답하면 개정을 통째로 놓쳤다. 픽스처 날짜는 실행 시점
+  // 비의존이 되도록 미래분을 2099년으로 치환한 동형 구조.
+  it("이미 시행된 슬라이스가 현행으로 잡히고, 시행 예정 개정이 경고된다", async () => {
+    const client = {
+      searchLaw: async () => searchXml("형사소송법", "281865"),
+      fetchApi: async (p: FetchApiParams) => {
+        if (p.target === "lsHistory") {
+          return histPage(4, [
+            histRow("형사소송법", "281865", "20991231", "21241", "2025.12.30", "일부개정"),  // 미래 슬라이스 (같은 MST)
+            histRow("형사소송법", "288579", "20990102", "21857", "2026.08.04", "일부개정"),  // 시행 예정 개정
+            histRow("형사소송법", "281865", "20260701", "21241", "2025.12.30", "일부개정"),  // 이미 시행된 슬라이스
+            histRow("형사소송법", "280441", "20260624", "21100", "2025.12.23", "일부개정"),
+          ])
+        }
+        if (p.target === "eflaw") return EFLAW_EMPTY_XML
+        if (p.target === "law") return `{"법령":{"부칙":{"부칙단위":[]}}}`
+        throw new Error(`unexpected target: ${p.target}`)
+      },
+    } as unknown as LawApiClient
+
+    const r = await applicableLaw(client, { lawName: "형사소송법", date: "2026-08-19" })
+    const text = r.content[0].text
+    // ① 현행 = 이미 시행된 슬라이스 (MST 단독 dedup였으면 20260624판으로 밀림)
+    expect(text).toContain("[시행 2026.07.01]")
+    expect(text).toContain("(MST 281865)")
+    expect(text).not.toContain("[시행 2026.06.24]")
+    // ② 시행 예정 개정 경고 + 후속 조회 유도
+    expect(text).toContain("시행 예정 개정")
+    expect(text).toContain("제21857호")
+    expect(text).toContain('get_law_text(mst="288579")')
+  })
+
+  it("시행 예정 개정이 없으면 경고를 내지 않는다", async () => {
+    const client = {
+      searchLaw: async () => searchXml("형사소송법", "281865"),
+      fetchApi: async (p: FetchApiParams) => {
+        if (p.target === "lsHistory") {
+          return histPage(1, [histRow("형사소송법", "281865", "20260701", "21241", "2025.12.30", "일부개정")])
+        }
+        if (p.target === "eflaw") return EFLAW_EMPTY_XML
+        if (p.target === "law") return `{"법령":{"부칙":{"부칙단위":[]}}}`
+        throw new Error(`unexpected target: ${p.target}`)
+      },
+    } as unknown as LawApiClient
+
+    const r = await applicableLaw(client, { lawName: "형사소송법", date: "2026-08-19" })
+    expect(r.content[0].text).not.toContain("시행 예정 개정")
+  })
+})
+
 describe("applicableLaw — 조문 응답 정직성 (jo 검증)", () => {
   beforeEach(() => lawCache.clear())
 

--- a/src/tools/applicable-law.ts
+++ b/src/tools/applicable-law.ts
@@ -230,6 +230,16 @@ export async function applicableLaw(
       lines.push(`  ↳ 이 버전이 현행입니다 (기준일 이후 개정 없음)`)
     }
 
+    // 시행 예정 개정 경고 — 연혁(versions)에 이미 들어 있는 미래 시행분에서 추출 (추가 API 호출 없음).
+    // 현행만 보고 답하면 곧 시행될 대개정을 통째로 놓친다 (2026-08-19 실측: 형사소송법
+    // 2026.10.2. 시행 제21857호 — §215조의2 검사 직권 삭제·§245조의7③ 이의신청 3개월 기한
+    // 신설을 도구가 완전 침묵, 외부 PDF로만 발견됨).
+    const upcoming = versions.filter(v => v.efYd && v.efYd > today)
+    if (upcoming.length > 0) {
+      const next = upcoming[upcoming.length - 1]  // versions는 시행일 내림차순 — 마지막이 최근접 미래
+      lines.push(`  ⚠️ 시행 예정 개정 ${upcoming.length}건 존재 — 최근접: 시행 ${fmtYmd(next.efYd)} (제${next.ancNo}호, ${next.rrCls || "개정"}). 기준일 판단에는 영향 없으나, 현행 인용이나 향후 절차 관련 서면에는 개정 내용 확인 필수: get_law_text(mst="${next.mst}")`)
+    }
+
     // 3. 조문 비교 (jo 지정 시)
     const joDisplay = input.jo ? (input.jo.startsWith("제") ? input.jo : `제${input.jo}`) : undefined
     if (joDisplay) {


### PR DESCRIPTION
## 실측 결함 2건 (2026-08-19, 형사소송법)

### (A) applicable_law가 현행 버전을 오판정

`legal_analysis(mode=applicable_law, lawName=형사소송법, date=2026-08-19)` → 시행 2026.6.24.(MST 280441)를 "현행"으로 반환. 실제 현행은 시행 2026.7.1.(MST 281865).

원인: lsHistory는 분리시행 공포본을 **같은 MST의 여러 행**(시행일별)으로 내보내는데(MST 281865 = 시행 2026.7.1. + 2027.12.31.), `fetchHistoricalVersionsFull`의 중복 제거 키가 MST 단독이라 시행일 내림차순 첫 행(미래 시행분)만 남고 이미 시행된 슬라이스가 사라짐 → `efYd <= today` 탐색이 그 MST를 통째로 건너뜀.

수리: dedup 키를 `MST` → `MST:efYd` 쌍으로. (time_travel의 pickVersion도 같은 목록을 쓰므로 함께 정확해집니다.)

### (B) get_law_text(mst=현행 아닌 버전) → NOT_FOUND

`get_law_text(mst=288579)`(시행 2026.10.2. 예정판) → NOT_FOUND. 과거 연혁판(MST 280441)도 동일.

원인: `lawService.do?target=eflaw`는 MST 단독(efYd 미동반)으로 현행이 아닌 버전을 못 풀고 200 + `{}`를 반환. 같은 MST를 `target=law`로 치면 부칙 포함 전문이 정상 회수됨(MST는 버전 고유값이라 안전).

수리: getLawText에서 법령 노드가 빈 응답이면 `target=law`로 1회 폴백.

### (+) applicable_law에 시행 예정 개정 경고

이미 확보한 연혁(versions)의 미래 시행분에서 추출 — 추가 API 호출 0. 현행 인용만 보고 답하면 곧 시행될 대개정(2026.10.2. 법률 제21857호 — 제215조의2 검사 직권 삭제, 제245조의7제3항 이의신청 3개월 기한 신설 등)을 통째로 놓치는 갭이 실제로 발생했습니다.

## 검증

- vitest 709/709 통과 (회귀 테스트 8건 추가), tsc 클린
- 실 API 검증: applicable_law(형사소송법@2026-08-19) → [시행 2026.07.01] (MST 281865) + 시행 예정 개정 2건 경고 / get_law_text(mst=288579, jo=제215조의2) → 시행 예정판 전문 + 기존 "시행 예정 버전" 경고 정상 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)