### PR TITLE
fix(api-client): eflaw HTML 에러 페이지도 target=law 폴백에 도달하도록 (#153)

### DIFF
--- a/src/lib/api-client.eflaw-fallback.test.ts
+++ b/src/lib/api-client.eflaw-fallback.test.ts
@@ -104,3 +104,76 @@ describe("getLawText — efYd 지정 요청은 폴백 대상이 아니다", () =
     expect(urls.some(u => u.includes("target=law&"))).toBe(false)
   })
 })
+
+// 회귀 (#153, 2026-08-27 법제처 변경): eflaw 단건 조회가 efYd를 요구하게 바뀌면서
+// MST 단독 요청의 실패 양상이 "200 + 빈 봉투"에서 "200 + HTML 안내 페이지"로 바뀌었다.
+// checkHtmlError가 폴백보다 먼저 던지고 있어서 위 폴백이 통째로 무력화됐고, 실존
+// 조문이 전부 조회 불가가 됐다(verify_citations는 전건 ⚠로 떨어짐).
+// target=law + 같은 MST는 정상 응답하며, 응답 구조도 eflaw와 동일하다
+// (2026-08-29 실측: 아동복지법 MST 285697 / JO 007500 → 법령.조문.조문단위[0]
+//  조문번호 75, 조문제목 "과태료", 시행일자 20260804 — eflaw+ID=000190 결과와 일치).
+const HTML_ERROR_PAGE = `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>국가법령정보 공동활용</title></head>
+<body>미신청된 목록/본문에 대한 접근입니다.</body></html>`
+
+const htmlRes = () =>
+  new Response(HTML_ERROR_PAGE, { status: 200, headers: { "content-type": "text/html" } })
+
+describe("getLawText — eflaw HTML 안내 페이지도 law 타깃 폴백을 타야 한다 (#153)", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("eflaw가 HTML 에러 페이지를 주면 던지지 않고 target=law로 폴백한다", async () => {
+    const urls: string[] = []
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      urls.push(String(url))
+      return String(url).includes("target=eflaw") ? htmlRes() : jsonRes(LAW_BODY)
+    }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    const text = await client.getLawText({ mst: "285697", jo: "007500" })
+
+    // HTML 응답은 fetchWithRetry의 재시도 사다리를 타므로 호출 수는 고정되지 않는다.
+    // 단정할 것은 "eflaw로 시작해 law로 넘어갔고, 식별자를 그대로 들고 갔다"는 전이다.
+    expect(text).toContain("기본정보")
+    expect(urls[0]).toContain("target=eflaw")
+    const fbUrls = urls.filter(u => u.includes("target=law"))
+    expect(fbUrls.length).toBeGreaterThan(0)
+    expect(fbUrls[0]).toContain("MST=285697")
+    expect(fbUrls[0]).toContain("JO=007500")
+  }, 30000)
+
+  it("폴백까지 HTML이면 그때는 던진다 (조용한 성공으로 위장하지 않는다)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => htmlRes()))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    await expect(client.getLawText({ mst: "285697", jo: "007500" }))
+      .rejects.toThrow(/법령 조문\(007500\)을 찾을 수 없습니다/)
+  }, 30000)
+
+  it("폴백 대상이 아닌 lawId 단독 조회는 HTML이면 종전대로 즉시 던진다", async () => {
+    const urls: string[] = []
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => { urls.push(String(url)); return htmlRes() }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    await expect(client.getLawText({ lawId: "000190" })).rejects.toThrow(/법령을 찾을 수 없습니다/)
+    expect(urls.some(u => u.includes("target=law"))).toBe(false)
+  }, 30000)
+
+  it("efYd 동반 요청은 HTML이어도 폴백하지 않고 즉시 던진다 (슬라이스 오염 방지 유지)", async () => {
+    const urls: string[] = []
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => { urls.push(String(url)); return htmlRes() }))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    await expect(client.getLawText({ mst: "281865", efYd: "20260701" })).rejects.toThrow()
+    expect(urls[0]).toContain("target=eflaw")
+    expect(urls.some(u => u.includes("target=law"))).toBe(false)
+  }, 30000)
+
+  it("type을 JSON으로 하드코딩한 호출에는 LAW_RESPONSE_TYPE=JSON 우회 안내를 붙이지 않는다", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => htmlRes()))
+
+    const client = new LawApiClient({ apiKey: "test" })
+    await expect(client.getLawText({ lawId: "000190" }))
+      .rejects.toThrow(/^(?!.*LAW_RESPONSE_TYPE).*$/s)
+  }, 30000)
+})

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -84,10 +84,18 @@ export class LawApiClient {
     return t === "JSON" ? "JSON" : "XML"
   }
 
-  /** 응답 본문이 HTML 에러 페이지인지 확인 (술어는 body-shape.ts 단일 원본) */
-  private checkHtmlError(text: string, context: string): void {
+  /**
+   * 응답 본문이 HTML 에러 페이지인지 확인 (술어는 body-shape.ts 단일 원본)
+   *
+   * `sentType`은 **그 호출이 실제로 보낸** type이다. 기본값인 `getResponseType()`을
+   * 그대로 쓰면 type을 하드코딩하는 메서드(getLawText 등 `type: "JSON"`)의 실패에
+   * "LAW_RESPONSE_TYPE=JSON으로 우회하라"는 안내가 항상 붙는다 — 이미 JSON으로 부른
+   * 호출이라 구조상 효과가 없는 안내다(#153 곁가지). 우회 안내는 실제로 XML을 보낸
+   * 호출에만 붙어야 한다.
+   */
+  private checkHtmlError(text: string, context: string, sentType: "XML" | "JSON" = this.getResponseType()): void {
     if (isHtmlPage(text)) {
-      const hint = this.getResponseType() === "XML"
+      const hint = sentType === "XML"
         ? " XML 엔드포인트 장애 시 LAW_RESPONSE_TYPE=JSON 환경변수로 우회할 수 있습니다."
         : ""
       throw new Error(`${context} - API가 HTML 에러 페이지를 반환했습니다. 파라미터를 확인해주세요.${hint}`)
@@ -170,9 +178,9 @@ export class LawApiClient {
 
     const text = await this.readBody(response, "법령 조회")
 
-    this.checkHtmlError(text, params.jo
+    const notFoundContext = params.jo
       ? `법령 조문(${params.jo})을 찾을 수 없습니다. MST/lawId와 조문번호를 확인해주세요.`
-      : "법령을 찾을 수 없습니다. MST 또는 법령명을 확인해주세요.")
+      : "법령을 찾을 수 없습니다. MST 또는 법령명을 확인해주세요."
 
     // eflaw 단건 조회는 MST 단독(efYd 미동반)으로 "현행이 아닌" 버전을 못 푼다 —
     // 시행 예정판·과거 연혁판 모두 200 + "{}"로 온다 (2026-08-19 형사소송법 실측:
@@ -183,7 +191,17 @@ export class LawApiClient {
     // 공포본이면 target=law가 마지막 시행 슬라이스를 돌려준다(실측: MST 281865 →
     // 시행 20271231, 시행 중인 20260701 아님). 시행일을 못박은 호출에 다른 슬라이스를
     // 끼워 넣으면 NOT_FOUND보다 나쁜 조용한 오답(행위시법 조문 비교 오염)이 된다.
-    if (params.mst && !params.efYd && !hasLawNode(text)) {
+    const canFallBackToLaw = Boolean(params.mst) && !params.efYd
+
+    // 같은 MST 단독 조회가 2026-08-27부터 빈 봉투 대신 **HTML 안내 페이지**로 실패한다
+    // (법제처가 eflaw 단건에 efYd를 요구하게 바뀜, #153). 두 응답은 "이 파라미터 조합으로는
+    // 못 푼다"는 같은 신호이므로 같은 폴백으로 흘려야 한다. HTML을 여기서 즉시 던지면
+    // 아래 폴백에 **도달하지 못해** 실존 조문이 통째로 조회 불가가 된다 — 기존 폴백이
+    // 무력화된 경로가 정확히 이것이다. 폴백 대상이 아닌 호출(lawId 단독·efYd 동반)은
+    // 종전대로 여기서 즉시 던진다.
+    if (!canFallBackToLaw) this.checkHtmlError(text, notFoundContext, "JSON")
+
+    if (canFallBackToLaw && (isHtmlPage(text) || !hasLawNode(text))) {
       const fbParams = new URLSearchParams({
         target: "law",
         OC: this.getApiKey(params.apiKey),
@@ -197,11 +215,13 @@ export class LawApiClient {
       await this.throwIfError(fbResponse, "getLawText")
 
       const fbText = await this.readBody(fbResponse, "법령 조회")
-      this.checkHtmlError(fbText, params.jo
-        ? `법령 조문(${params.jo})을 찾을 수 없습니다. MST/lawId와 조문번호를 확인해주세요.`
-        : "법령을 찾을 수 없습니다. MST 또는 법령명을 확인해주세요.")
+      this.checkHtmlError(fbText, notFoundContext, "JSON")
       if (hasLawNode(fbText)) return fbText
     }
+
+    // 폴백이 원 응답을 대체하지 못했다. 원 응답이 HTML이면 여기서 확정한다 —
+    // 빈 봉투는 종전대로 그대로 돌려보내 상위 레이어가 NOT_FOUND로 표면화한다.
+    this.checkHtmlError(text, notFoundContext, "JSON")
 
     return text
   }


### PR DESCRIPTION
안녕하세요. 이슈 #153에서 보고된 `get_law_text` 장애를, 이미 있는 `target=law` 폴백에 HTML 실패 응답이 도달하도록 고쳐 해결했습니다.

좋은 도구 만들어 공개해 주셔서 감사합니다. 덕분에 잘 쓰고 있고, 쓰다 마주친 문제라 원인까지 파본 뒤 고쳐 보냅니다. 혹시 방향이 맞지 않으면 편하게 말씀해 주세요.

## 관련 이슈

- #153 (이 PR로 본문 이슈와 곁가지 1이 해소됩니다)

## 문제

2026-08-27부터 법제처가 `lawService.do?target=eflaw` 단건 조회에 `efYd`를 요구합니다. 그래서 MST 단독 요청이 종전의 **200 + 빈 봉투(`{}`)** 대신 **200 + HTML 안내 페이지**로 실패합니다.

`getLawText`에는 바로 이 조합을 위한 폴백이 이미 있습니다.

```js
if (params.mst && !params.efYd && !hasLawNode(text)) { /* target=law 폴백 */ }
```

그런데 `checkHtmlError`가 이 위에서 throw하기 때문에 **폴백에 도달하지 못합니다.** 결과적으로 실존 조문이 통째로 조회 불가가 되고, 이 경로만 타는 `verify_citations`는 모든 인용을 `⚠`로 보고합니다.

보고자와 별개로 재현했고, **API 키 없이 공개 서버(`https://mcp.gomdori.app/law`)에서도 동일하게 재현**됩니다. 특정 키나 계정 범위의 문제가 아닙니다.

## 사용자 가시 효과

- **복구**: `get_law_text`에 `mst`만 넘기는 호출이 다시 조문 본문을 반환합니다. `search_law` 응답이 안내하는 `get_law_text(mst=...)` 경로가 바로 이 조합이라, 사용자가 가장 먼저 밟는 길이 막혀 있던 상태였습니다.
- **연쇄 복구**: `verify_citations`가 조문 실존 검증을 다시 수행합니다. `legal_analysis(mode=verify_citations)`도 같습니다.
- **오해 소지 제거**: 실패 메시지에서 효과 없는 `LAW_RESPONSE_TYPE=JSON` 안내가 사라집니다.
- **동작 변화 없음**: `lawId` 단독 조회, `efYd` 동반 조회, 정상 응답 경로는 종전과 동일합니다.
- 보안 영향은 없습니다. 인증·권한·키 취급 경로를 건드리지 않았습니다.

## 변경 내용

`getLawText`의 오류 경로에 대한 두 가지 변경입니다.

**1. 두 실패 양상을 같은 폴백으로 흘립니다.** 빈 봉투와 HTML 안내 페이지는 "이 파라미터 조합으로는 풀 수 없다"는 같은 신호이므로 같은 복구를 타야 합니다. 원 응답은 폴백까지 법령 노드를 얻지 못했을 때만 던집니다.

폴백 대상이 아닌 호출은 종전대로 즉시 던집니다.

- `lawId` 단독 — 이번 상류 변경의 영향을 받지 않습니다. `efYd` 없이도 정상 조회됨을 확인했습니다.
- `efYd` 동반 — #152의 "조용한 슬라이스 대체 금지" 불변식을 유지합니다. 분리시행 공포본에서 `target=law`는 지정한 시점이 아니라 마지막 슬라이스를 돌려주기 때문입니다.

**2. `LAW_RESPONSE_TYPE=JSON` 우회 안내를 실제로 XML을 보낸 호출로 좁힙니다** (이슈의 곁가지 1). `getLawText`는 `type: "JSON"`을 하드코딩하는데 `getResponseType()`은 환경변수 기본값 `XML`을 돌려주므로, 이 안내가 도움이 될 수 없는 호출에 항상 따라붙고 있었습니다. `checkHtmlError`에 선택 인자 `sentType`을 더하고 기본값을 종전 동작(`getResponseType()`)으로 두어, 다른 호출부는 그대로입니다.

## 이슈의 미확인 지점에 대한 답

이슈는 A안(`verifyOne`이 `lawId`로 폴백)과 B안(기존 MST 폴백이 작동하도록 순서 조정)을 제시하면서, B안의 걸림돌로 **`target=law` 응답의 조문 구조를 확인하지 못했다**는 점을 남겨 두셨습니다. 그 부분을 실서버로 확인했습니다.

**2026-08-29 실측 — `target=law`는 `eflaw`와 동일한 구조로 응답합니다.**

| 호출 | 조문번호 | 조문제목 | 시행일자 |
|---|---|---|---|
| `target=law&MST=285697&JO=007500` | 75 | 과태료 | 20260804 |
| `target=eflaw&ID=000190&JO=007500` | 75 | 과태료 | — |

둘 다 `법령.조문.조문단위[]` 아래에 들어옵니다. 따라서 B안이 안전하고, `verify_citations` 한 곳이 아니라 `getLawText`를 쓰는 **모든 호출자**가 복구됩니다. A안은 여전히 유효한 추가 방어막이지만 복구를 위해 반드시 필요하지는 않습니다. 원하시면 A안도 따로 보내드리겠습니다.

## 검증

CONTRIBUTING의 네 가지를 모두 실행했고 전부 통과했습니다.

```
npm ci --ignore-scripts
npm run typecheck      # 통과
npm test               # 76개 파일, 717 테스트 통과 (종전 706 + 신규 11)
npm run build          # 통과
npm run verify:package # package artifacts verified (272 packed files)
```

패키징을 건드리지 않아 `npm pack --dry-run`은 별도로 돌리지 않았습니다. 필요하시면 실행해서 결과 붙이겠습니다.

**실서버 before/after** (실제 OC 키, MCP stdio 서버 종단 간):

| 호출 | 4.12.1 | 이 브랜치 |
|---|---|---|
| `get_law_text(mst=284415, jo=제700조)` | ❌ `EXTERNAL_API_ERROR` | ✅ 민법 제700조 (임치물의 반환장소) |
| `get_law_text(mst=285697, jo=제75조)` — 이슈 사례 | ❌ | ✅ 아동복지법 제75조 (과태료) |
| `get_law_text(lawId=001706, jo=제700조)` | ✅ | ✅ 변화 없음 |
| `get_law_text(mst=284415, jo=제700조, efYd=20260317)` | ✅ | ✅ 변화 없음, 시점 지정 버전 경고도 그대로 |

**신규 회귀 테스트 5건** (`api-client.eflaw-fallback.test.ts`):

- HTML 응답 → 폴백 성공, `MST`·`JO`를 그대로 이어받음
- 폴백까지 HTML → 그때는 던짐 (조용한 성공으로 위장하지 않음)
- `lawId` 단독 → 폴백 없이 즉시 던짐
- `efYd` 동반 → 폴백 없이 즉시 던짐
- `type=JSON` 하드코딩 호출의 메시지에 `LAW_RESPONSE_TYPE` 안내가 붙지 않음

테스트 작성 시 참고하실 점이 하나 있습니다. HTML 응답은 `fetchWithRetry`의 재시도 사다리를 타기 때문에 호출 횟수가 고정되지 않습니다. 그래서 정확한 카운트 대신 **eflaw → law 타깃 전이**로 단정했고, 30초 타임아웃을 줬습니다. 기본 5초로 두면 타임아웃된 요청의 남은 재시도가 **다음 테스트의 `fetch` 스텁으로 넘어가 오염**시킵니다(실제로 겪었습니다).

## 검증하지 않은 부분

정직하게 밝혀 둡니다.

- **HTTP 서버·Docker·fly 배포 경로는 검증하지 않았습니다.** 변경 지점이 `api-client`라 배포 형태와 무관하다고 판단했지만, 통합 호스트(gomdori-mcp) 쪽 반영은 확인할 수 없는 위치에 있습니다.
- **클라우드 IP 안티봇 우회 경로(v4.6.0)와의 상호작용은 확인하지 않았습니다.** 제 검증은 한국 로컬 IP와 공개 서버 두 경로였습니다.
- **분리시행 공포본의 실제 케이스(MST 281865 등)는 유닛 테스트로만 확인했고 실서버로 재확인하지 않았습니다.** `efYd` 동반 요청이 폴백을 타지 않는다는 불변식은 유지되지만, 그 판단의 근거가 된 실측은 기존 주석·테스트에 의존했습니다.
- **429·레이트리밋 경로는 건드리지 않았고 테스트하지도 않았습니다.**

## 이 PR에 넣지 않은 것

**곁가지 2(`get_historical_law`가 `제undefined조`를 출력하는 문제)는 제외했습니다.** 이 PR을 `getLawText` 오류 경로에 집중시키기 위해서이고, 보고자께서도 독립된 문제로 분리해 적어 두셨기 때문입니다.

다만 확인은 했고 진단이 맞습니다. `src/tools/historical-law.ts:158`이 `law.조문`을 조문 객체의 배열로 읽는데, 실제 페이로드는 한 겹 더 감싼 `법령.조문.조문단위[]` 구조입니다. 이는 `verify-citations.ts:296`과 `applicable-law.ts:63`이 이미 읽고 있는 형태와 같습니다. 그래서 배열 길이가 1(`{조문단위: [...]}` 래퍼)이 되고 `조문번호`가 `undefined`로 나옵니다.

이 건은 별도 PR로 보내드리는 게 좋을지, 아니면 여기 함께 넣는 게 나을지 말씀해 주시면 그대로 따르겠습니다.

## 덧붙임

교육 과정에서 이 서버를 쓸 수 있을지 검토하다가 문제를 만났고, 원인을 파고 든 김에 보고자께서 제안하신 B안 형태로 고쳐 보냈습니다. 복구 방식을 다른 모양으로 가져가고 싶으시면 기꺼이 다시 작업하겠습니다. 검토해 주셔서 감사합니다.
