### PR TITLE
fix(knowledge-base): 존재하지 않는 법제처 target 3건으로 연계 도구 4개가 조용히 0건

### DIFF
--- a/src/tools/knowledge-base.test.ts
+++ b/src/tools/knowledge-base.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest"
+import { getRelatedLaws, getTermArticles, getDailyToLegal, getLegalToDaily } from "./knowledge-base.js"
+import type { LawApiClient } from "../lib/api-client.js"
+
+// 실측 응답 축약. 조회링크 필드는 인증키(OC)가 박혀 있고 파싱 대상도 아니라 뺐다.
+//
+// 세 응답 모두 항목이 한글 래퍼(<관련법령>/<연계법령>/<연계용어>)에 들어 있고,
+// <검색결과개수>는 기준 법령·기준 용어의 개수(=1)이지 연계 항목 수가 아니다.
+
+// lawSearch.do?target=lsRlt&query=건축법
+const RELATED_LAWS_XML = `<?xml version="1.0" encoding="UTF-8"?><lsRltSearch><target>lsRlt</target><키워드>건축법</키워드><검색결과개수>1</검색결과개수>
+<법령 id="1"><기준법령ID>001766</기준법령ID><기준법령명><![CDATA[건축법]]></기준법령명>
+<관련법령 id="1"><관련법령ID>010594</관련법령ID><관련법령명><![CDATA[건축기본법]]></관련법령명><법령간관계코드>140503</법령간관계코드><법령간관계>3유형(기본법)</법령간관계></관련법령>
+<관련법령 id="2"><관련법령ID>001767</관련법령ID><관련법령명><![CDATA[건축법 시행령]]></관련법령명><법령간관계코드>140506</법령간관계코드><법령간관계>6유형(하위법)</법령간관계></관련법령>
+<관련법령 id="3"><관련법령ID>001768</관련법령ID><관련법령명><![CDATA[건축법 시행규칙]]></관련법령명><법령간관계코드>140506</법령간관계코드><법령간관계>6유형(하위법)</법령간관계></관련법령>
+</법령></lsRltSearch>`
+
+// lawService.do?target=lstrmRltJo&query=임대차
+// 조문제목 필드가 따로 없어 조문내용 머리에서 뽑는다. 농지법은 제24조와 제24조의2가 나란히 온다.
+const TERM_ARTICLES_XML = `<?xml version="1.0" encoding="UTF-8"?><lstrmRltJoService><target>lstrmRltJo</target><키워드>임대차</키워드><검색결과개수>1</검색결과개수>
+<법령용어 id="1"><법령용어명>임대차</법령용어명>
+<연계법령 id="1"><법령명><![CDATA[농어촌정비법]]></법령명><조번호>0085</조번호><조가지번호>00</조가지번호><조문내용><![CDATA[제85조(농어촌관광휴양지사업자의 신고 등) ① 농어촌 관광휴양단지사업은 …]]></조문내용><용어구분>핵심용어</용어구분></연계법령>
+<연계법령 id="2"><법령명><![CDATA[농지법]]></법령명><조번호>0024</조번호><조가지번호>00</조가지번호><조문내용><![CDATA[제24조(임대차ㆍ사용대차 계약 방법과 확인) ① 임대차계약과 사용대차계약은 …]]></조문내용><용어구분>핵심용어</용어구분></연계법령>
+<연계법령 id="3"><법령명><![CDATA[농지법]]></법령명><조번호>0024</조번호><조가지번호>02</조가지번호><조문내용><![CDATA[제24조의2(임대차 기간) ① 제23조제1항 각 호(제8호는 제외한다)의 임대차 기간은 3년 이상으로 하여야 한다. …]]></조문내용><용어구분>핵심용어</용어구분></연계법령>
+</법령용어></lstrmRltJoService>`
+
+// lawService.do?target=lstrmRlt&query=임대차
+const RELATED_TERMS_XML = `<?xml version="1.0" encoding="UTF-8"?><lstrmRltService><target>lstrmRlt</target><키워드>임대차</키워드><검색결과개수>1</검색결과개수>
+<법령용어 id="1"><법령용어명>임대차</법령용어명>
+<연계용어 id="1"><일상용어명><![CDATA[반전세]]></일상용어명><용어관계코드>140305</용어관계코드><용어관계>연관어</용어관계></연계용어>
+<연계용어 id="2"><일상용어명><![CDATA[월세]]></일상용어명><용어관계코드>140305</용어관계코드><용어관계>연관어</용어관계></연계용어>
+</법령용어></lstrmRltService>`
+
+// 오타 target에 대한 법제처 응답. HTTP 200 + 빈 본문이라 예외가 안 난다.
+const EMPTY_BODY = ""
+
+type FetchArgs = Parameters<LawApiClient["fetchApi"]>[0]
+
+/** fetchApi 호출 인자를 잡아 두는 스텁 — target/endpoint 회귀를 막는 것이 목적 */
+function recordingStub(xml: string) {
+  const calls: FetchArgs[] = []
+  const client = {
+    fetchApi: async (options: FetchArgs) => {
+      calls.push(options)
+      return xml
+    },
+  } as unknown as LawApiClient
+  return { client, calls }
+}
+
+describe("지식베이스 연계 도구의 법제처 target (#428)", () => {
+  it("get_related_laws는 lawSearch.do의 lsRlt를 부른다", async () => {
+    const { client, calls } = recordingStub(RELATED_LAWS_XML)
+    await getRelatedLaws(client, { lawName: "건축법", display: 20 })
+
+    expect(calls[0].endpoint).toBe("lawSearch.do")
+    expect(calls[0].target).toBe("lsRlt")
+  })
+
+  it("get_term_articles는 lawService.do의 lstrmRltJo를 부른다", async () => {
+    const { client, calls } = recordingStub(TERM_ARTICLES_XML)
+    await getTermArticles(client, { term: "임대차", display: 20 })
+
+    expect(calls[0].endpoint).toBe("lawService.do")
+    expect(calls[0].target).toBe("lstrmRltJo")
+  })
+
+  it("용어 연계 두 도구는 lawService.do의 lstrmRlt를 부른다", async () => {
+    const daily = recordingStub(RELATED_TERMS_XML)
+    await getDailyToLegal(daily.client, { dailyTerm: "월세" })
+    const legal = recordingStub(RELATED_TERMS_XML)
+    await getLegalToDaily(legal.client, { legalTerm: "임대차" })
+
+    for (const calls of [daily.calls, legal.calls]) {
+      expect(calls[0].endpoint).toBe("lawService.do")
+      expect(calls[0].target).toBe("lstrmRlt")
+    }
+  })
+
+  it("lstrmRlt에 없는 relType은 보내지 않는다", async () => {
+    const { client, calls } = recordingStub(RELATED_TERMS_XML)
+    await getDailyToLegal(client, { dailyTerm: "월세" })
+
+    expect(calls[0].extraParams).not.toHaveProperty("relType")
+  })
+})
+
+describe("지식베이스 연계 응답 파싱", () => {
+  it("관련법령을 한글 래퍼에서 읽고 관계유형·법령ID를 함께 낸다", async () => {
+    const { client } = recordingStub(RELATED_LAWS_XML)
+    const r = await getRelatedLaws(client, { lawName: "건축법", display: 20 })
+
+    expect(r.isError).toBeUndefined()
+    const text = r.content[0].text
+    expect(text).toContain("관련법령 (3건)")
+    expect(text).toContain("건축기본법")
+    expect(text).toContain("3유형(기본법)")
+    expect(text).toContain("010594")
+  })
+
+  it("연계 항목 수를 총건수로 쓴다 — <검색결과개수>는 기준 법령 개수(1)다", async () => {
+    const { client } = recordingStub(RELATED_LAWS_XML)
+    const r = await getRelatedLaws(client, { lawName: "건축법", display: 20 })
+
+    expect(r.content[0].text).not.toContain("관련법령 (1건)")
+  })
+
+  it("가지번호 조문은 제24조의2로 적는다 (제24의2조 아님)", async () => {
+    const { client } = recordingStub(TERM_ARTICLES_XML)
+    const r = await getTermArticles(client, { term: "임대차", display: 20 })
+
+    const text = r.content[0].text
+    expect(text).toContain("제24조의2 (임대차 기간)")
+    expect(text).not.toContain("제24의2조")
+    // 가지번호 없는 조문은 종전대로
+    expect(text).toContain("제85조 (농어촌관광휴양지사업자의 신고 등)")
+  })
+
+  it("lawService.do가 display를 무시하므로 건수는 파서에서 자른다", async () => {
+    const { client, calls } = recordingStub(TERM_ARTICLES_XML)
+    const r = await getTermArticles(client, { term: "임대차", display: 2 })
+
+    expect(calls[0].extraParams).not.toHaveProperty("display")
+    expect(r.content[0].text).toContain("(2건)")
+    expect(r.content[0].text).not.toContain("제24조의2")
+  })
+
+  it("연계용어를 읽어 양방향 연계를 낸다", async () => {
+    const daily = recordingStub(RELATED_TERMS_XML)
+    const dailyResult = await getDailyToLegal(daily.client, { dailyTerm: "월세" })
+    expect(dailyResult.content[0].text).toContain("반전세")
+
+    const legal = recordingStub(RELATED_TERMS_XML)
+    const legalResult = await getLegalToDaily(legal.client, { legalTerm: "임대차" })
+    expect(legalResult.content[0].text).toContain("월세")
+  })
+})
+
+describe("오타 target의 빈 본문 (HTTP 200 + 0바이트)", () => {
+  it("get_related_laws는 예외 없이 NOT_FOUND로 끝난다", async () => {
+    const { client } = recordingStub(EMPTY_BODY)
+    const r = await getRelatedLaws(client, { lawName: "건축법", display: 20 })
+
+    expect(r.isError).toBe(true)
+    expect(r.content[0].text).toContain("[NOT_FOUND]")
+  })
+
+  it("get_term_articles는 예외 없이 NOT_FOUND로 끝난다", async () => {
+    const { client } = recordingStub(EMPTY_BODY)
+    const r = await getTermArticles(client, { term: "임대차", display: 20 })
+
+    expect(r.isError).toBe(true)
+    expect(r.content[0].text).toContain("[NOT_FOUND]")
+  })
+})

--- a/src/tools/knowledge-base.ts
+++ b/src/tools/knowledge-base.ts
@@ -11,6 +11,68 @@ import { formatToolError, noResultHint } from "../lib/errors.js"
 // - 관련법령 조회
 // ============================================================================
 
+// ----------------------------------------------------------------------------
+// 연계 API(lstrmRlt / lstrmRltJo / lsRlt) 전용 파서
+//
+// 이 세 응답은 항목을 한글 래퍼(<연계용어>/<연계법령>/<관련법령>)에 담고 필드명도
+// 다르다. 공유 parseKBXML은 항목 태그를 ["lstrm","lstrmAI","law","jo","rel","item"]로
+// 고정하므로 여기서는 언제나 0건이 된다. parseKBXML은 정상 동작 중인 다른 도구
+// (get_legal_term_kb·get_daily_term·fallbackTermSearch)가 함께 쓰므로 손대지 않고,
+// 이 파일의 연계 도구 4개만 쓰는 파서를 둔다.
+//
+// <검색결과개수>는 기준 용어·기준 법령의 개수(항상 1)이지 연계 항목 수가 아니라
+// 총건수로 쓸 수 없다. 파싱한 항목 수를 총건수로 쓴다.
+// ----------------------------------------------------------------------------
+interface RelationItem {
+  법령명?: string
+  법령ID?: string
+  관계유형?: string
+  조문번호?: string
+  조문표기?: string
+  조문제목?: string
+  연계용어명?: string
+}
+
+function parseRelationXML(
+  xml: string,
+  itemTag: string,
+  mapItem: (content: string) => RelationItem | null,
+  limit?: number
+): RelationItem[] {
+  const items: RelationItem[] = []
+  const itemRegex = new RegExp(`<${itemTag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${itemTag}>`, "g")
+
+  for (const match of xml.matchAll(itemRegex)) {
+    const item = mapItem(match[1])
+    if (!item) continue
+
+    items.push(item)
+    if (limit && items.length >= limit) break
+  }
+
+  return items
+}
+
+/** <연계용어> 항목. 일상↔법령 양방향이 같은 target(lstrmRlt)을 쓰므로 공통이다. */
+function mapRelatedTerm(content: string): RelationItem | null {
+  const name = extractTag(content, "일상용어명") || extractTag(content, "법령용어명")
+  return name ? { 연계용어명: name } : null
+}
+
+/**
+ * 조번호 "0024" + 조가지번호 "02" → "제24조의2"
+ * 가지번호를 조 앞에 붙인 "제24의2조"는 존재하지 않는 조문 표기다.
+ */
+function formatArticleLabel(content: string): { 조문번호: string; 조문표기: string } {
+  const articleNumber = Number.parseInt(extractTag(content, "조번호") || "0", 10)
+  if (!articleNumber) return { 조문번호: "", 조문표기: "" }
+
+  const branchNumber = Number.parseInt(extractTag(content, "조가지번호") || "0", 10)
+  return branchNumber > 0
+    ? { 조문번호: `${articleNumber}의${branchNumber}`, 조문표기: `제${articleNumber}조의${branchNumber}` }
+    : { 조문번호: String(articleNumber), 조문표기: `제${articleNumber}조` }
+}
+
 // 1. 법령용어 지식베이스 조회 (lstrmAI)
 export const getLegalTermKBSchema = z.object({
   query: z.string().describe("검색할 법령용어"),
@@ -185,17 +247,15 @@ export async function getDailyToLegal(
     let xmlText: string;
     try {
       xmlText = await apiClient.fetchApi({
-        endpoint: "lawSearch.do",
-        target: "lstrmRel",
-        extraParams: { query: args.dailyTerm, relType: "DL" },
+        endpoint: "lawService.do",
+        target: "lstrmRlt",
+        extraParams: { query: args.dailyTerm },
         apiKey: args.apiKey,
       });
     } catch {
       return await fallbackTermSearch(apiClient, args.dailyTerm, "일상용어");
     }
-    const result = parseKBXML(xmlText, "LsTrmRelSearch");
-
-    const items = result.data || [];
+    const items = parseRelationXML(xmlText, "연계용어", mapRelatedTerm);
 
     if (items.length === 0) {
       return await fallbackTermSearch(apiClient, args.dailyTerm, "일상용어");
@@ -206,7 +266,7 @@ export async function getDailyToLegal(
     output += `관련 법령용어:\n`;
 
     for (const item of items) {
-      output += `   • ${item.법령용어명 || item.연계용어명}\n`;
+      output += `   • ${item.연계용어명}\n`;
     }
 
     return { content: [{ type: "text", text: truncateResponse(output) }] };
@@ -231,17 +291,15 @@ export async function getLegalToDaily(
     let xmlText: string;
     try {
       xmlText = await apiClient.fetchApi({
-        endpoint: "lawSearch.do",
-        target: "lstrmRel",
-        extraParams: { query: args.legalTerm, relType: "LD" },
+        endpoint: "lawService.do",
+        target: "lstrmRlt",
+        extraParams: { query: args.legalTerm },
         apiKey: args.apiKey,
       });
     } catch {
       return await fallbackTermSearch(apiClient, args.legalTerm, "법령용어");
     }
-    const result = parseKBXML(xmlText, "LsTrmRelSearch");
-
-    const items = result.data || [];
+    const items = parseRelationXML(xmlText, "연계용어", mapRelatedTerm);
 
     if (items.length === 0) {
       return await fallbackTermSearch(apiClient, args.legalTerm, "법령용어");
@@ -252,7 +310,7 @@ export async function getLegalToDaily(
     output += `관련 일상용어:\n`;
 
     for (const item of items) {
-      output += `   • ${item.일상용어명 || item.연계용어명}\n`;
+      output += `   • ${item.연계용어명}\n`;
     }
 
     return { content: [{ type: "text", text: truncateResponse(output) }] };
@@ -277,13 +335,12 @@ export async function getTermArticles(
   try {
     let xmlText: string;
     try {
+      // lawService.do는 display를 무시하고 연계 조문 전문을 통째로 준다
+      // (임대차 기준 196건·약 430KB). 건수 제한은 파서에서 건다.
       xmlText = await apiClient.fetchApi({
-        endpoint: "lawSearch.do",
-        target: "lstrmJo",
-        extraParams: {
-          query: args.term,
-          display: (args.display || 20).toString(),
-        },
+        endpoint: "lawService.do",
+        target: "lstrmRltJo",
+        extraParams: { query: args.term },
         apiKey: args.apiKey,
       });
     } catch {
@@ -295,12 +352,16 @@ export async function getTermArticles(
         isError: true,
       };
     }
-    const result = parseKBXML(xmlText, "LsTrmJoSearch");
+    const items = parseRelationXML(xmlText, "연계법령", (content) => {
+      const 법령명 = extractTag(content, "법령명");
+      if (!법령명) return null;
 
-    const totalCount = parseInt(result.totalCnt || "0");
-    const items = result.data || [];
+      // 조문제목은 별도 필드가 없어 조문내용 머리("제24조의2(임대차 기간)")에서 뽑는다
+      const title = (extractTag(content, "조문내용") || "").match(/제\d+조(?:의\d+)?\s*\(([^)]{1,60})\)/);
+      return { 법령명, ...formatArticleLabel(content), 조문제목: title ? title[1] : "" };
+    }, args.display || 20);
 
-    if (totalCount === 0 || items.length === 0) {
+    if (items.length === 0) {
       return {
         content: [{
           type: "text",
@@ -310,16 +371,15 @@ export async function getTermArticles(
       };
     }
 
-    let output = `'${args.term}' 용어 사용 조문 (${totalCount}건):\n\n`;
+    let output = `'${args.term}' 용어 사용 조문 (${items.length}건):\n\n`;
 
     for (const item of items) {
       output += `${item.법령명}\n`;
-      if (item.조문번호) {
-        output += `   제${item.조문번호}조`;
+      if (item.조문표기) {
+        output += `   ${item.조문표기}`;
         if (item.조문제목) output += ` (${item.조문제목})`;
         output += `\n`;
       }
-      if (item.법령ID) output += `   법령ID: ${item.법령ID}\n`;
       output += `\n`;
     }
 
@@ -360,7 +420,7 @@ export async function getRelatedLaws(
     try {
       xmlText = await apiClient.fetchApi({
         endpoint: "lawSearch.do",
-        target: "lawRel",
+        target: "lsRlt",
         extraParams,
         apiKey: args.apiKey,
       });
@@ -373,12 +433,18 @@ export async function getRelatedLaws(
         isError: true,
       };
     }
-    const result = parseKBXML(xmlText, "LawRelSearch");
+    const items = parseRelationXML(xmlText, "관련법령", (content) => {
+      const 법령명 = extractTag(content, "관련법령명");
+      if (!법령명) return null;
 
-    const totalCount = parseInt(result.totalCnt || "0");
-    const items = result.data || [];
+      return {
+        법령명,
+        법령ID: extractTag(content, "관련법령ID"),
+        관계유형: extractTag(content, "법령간관계"),
+      };
+    }, args.display || 20);
 
-    if (totalCount === 0 || items.length === 0) {
+    if (items.length === 0) {
       return {
         content: [{
           type: "text",
@@ -388,13 +454,12 @@ export async function getRelatedLaws(
       };
     }
 
-    let output = `관련법령 (${totalCount}건):\n\n`;
+    let output = `관련법령 (${items.length}건):\n\n`;
 
     for (const item of items) {
       output += `${item.법령명}\n`;
       if (item.관계유형) output += `   관계: ${item.관계유형}\n`;
       if (item.법령ID) output += `   법령ID: ${item.법령ID}\n`;
-      if (item.법령종류) output += `   종류: ${item.법령종류}\n`;
       output += `\n`;
     }
 


### PR DESCRIPTION
## 증상

법령정보 지식베이스 연계 도구 **4개가 에러 없이 항상 0건**을 냅니다.

| 도구 | 관측 결과 |
|---|---|
| `get_related_laws` | 항상 `[NOT_FOUND] 관련법령을 찾을 수 없습니다.` |
| `get_term_articles` | 항상 `[NOT_FOUND] '…' 용어가 사용된 조문을 찾을 수 없습니다.` |
| `get_daily_to_legal` | 항상 폴백(`fallbackTermSearch`) 결과로 대체됨 |
| `get_legal_to_daily` | 항상 폴백(`fallbackTermSearch`) 결과로 대체됨 |

예외가 나지 않아 재시도·폴백 로직에도 걸리지 않고, 사용자에게는 "해당 자료가 없다"로만 보입니다.

## 원인

`src/tools/knowledge-base.ts` 가 쓰는 법제처 OPEN API `target` 3개가 실재하지 않는 값입니다.

| 함수 | 현재 | 올바른 값 |
|---|---|---|
| `getDailyToLegal` · `getLegalToDaily` | `lawSearch.do` + `lstrmRel` | `lawService.do` + `lstrmRlt` |
| `getTermArticles` | `lawSearch.do` + `lstrmJo` | `lawService.do` + `lstrmRltJo` |
| `getRelatedLaws` | `lawSearch.do` + `lawRel` | `lawSearch.do` + `lsRlt` (엔드포인트 유지) |

법제처는 **잘못된 `target` 에 HTTP 200 + 빈 본문**을 줍니다. HTTP 에러도, XML 에러 메시지도 아니라
`fetchApi` 가 정상 반환하고 파서가 0건을 내는 것으로 끝납니다. 이 버그가 오래 남은 이유로 보입니다.

## 근거 — 존재하지 않는 target 을 대조군으로 둔 실측

`type=XML` 로 같은 조건에서 응답 바이트를 잰 결과입니다.

| 엔드포인트 | target | HTTP | 응답 크기 |
|---|---|---:|---:|
| `lawSearch.do` | `lstrmRel` (현재) | 200 | **0 bytes** |
| `lawSearch.do` | `lstrmJo` (현재) | 200 | **0 bytes** |
| `lawSearch.do` | `lawRel` (현재) | 200 | **0 bytes** |
| `lawSearch.do` | `bogus123` (**대조군 — 아예 없는 target**) | 200 | **0 bytes** |
| `lawService.do` | `lstrmRlt` (수정) | 200 | 4,619 bytes |
| `lawService.do` | `lstrmRltJo` (수정) | 200 | 439,240 bytes |
| `lawSearch.do` | `lsRlt` (수정) | 200 | 5,158 bytes |

**세 target 이 대조군과 바이트 단위로 동일**합니다. 즉 법제처가 이 셋을 "없는 target" 과 똑같이
취급하고 있으며, 파라미터 조합 문제나 일시적 빈 결과가 아닙니다.

`relType`(`DL`/`LD`)은 `lstrmRlt` 에 없는 파라미터라 함께 제거했습니다.

## target 만 고쳐서는 여전히 0건입니다

올바른 응답은 항목을 **한글 래퍼 태그**에 담고 필드명도 다릅니다.

```
lstrmRlt    : <lstrmRltService>   → <법령용어> → <연계용어>   (일상용어명 · 용어관계)
lstrmRltJo  : <lstrmRltJoService> → <법령용어> → <연계법령>   (법령명 · 조번호 · 조가지번호 · 조문내용)
lsRlt       : <lsRltSearch>       → <법령>     → <관련법령>   (관련법령명 · 관련법령ID · 법령간관계)
```

그런데 공유 파서 `src/tools/kb-utils.ts` 의 `parseKBXML()` 은 `rootTag` 인자를 쓰지 않고(`_rootTag`)
항목 태그를 `["lstrm","lstrmAI","law","jo","rel","item"]` 로 하드코딩합니다. 한글 래퍼가 목록에 하나도
없으므로 `target` 만 고치면 여전히 0건입니다.

`<검색결과개수>` 도 총건수로 쓸 수 없습니다 — **기준 용어·기준 법령의 개수(항상 1)** 이지 연계 항목 수가
아닙니다. 그래서 파싱한 항목 수를 총건수로 씁니다.

## 공유 파서를 건드리지 않은 이유

`parseKBXML()` 은 **지금 정상 동작 중인 다른 도구**(`get_legal_term_kb` · `get_daily_term` ·
`fallbackTermSearch`)가 함께 씁니다. 항목 태그 목록에 한글 래퍼를 더하거나 `rootTag` 를 살리는 쪽은
잘 돌던 3개 경로까지 회귀 위험에 넣습니다.

그래서 공유 파서는 그대로 두고, **이 파일의 연계 도구 4개만 쓰는 파서**(`parseRelationXML`)를
`knowledge-base.ts` 안에 두었습니다. 영향 범위가 고친 함수 4개로 닫힙니다.

`lawService.do` 는 `display` 를 무시하고 연계 조문 전문을 통째로 줍니다(`임대차` 기준 196건 · 약 430KB).
그래서 건수 제한을 파서 쪽에서 겁니다.

## 곁가지로 함께 고친 표기 오류

가지번호 조문이 **`제24의2조`** 로 출력되던 것을 **`제24조의2`** 로 바로잡았습니다(법령 인용 표기법).
`조번호`(`0024`) + `조가지번호`(`02`) 를 조합할 때 가지번호를 `조` 앞에 붙이고 있었습니다. 존재하지 않는
조문 번호를 그럴듯하게 내보내는 것은 이 프로젝트가 막으려는 환각과 같은 종류의 오류라 함께 고쳤습니다.
같은 파일 · 같은 출력 경로여서 PR 을 나누지 않았습니다.

## 검증

수정본으로 네 도구를 실제 호출한 결과입니다.

| 도구 | 입력 | 결과 |
|---|---|---|
| `get_related_laws` | `lawName="건축법", display=6` | ✅ **6건** — 건축기본법(3유형(기본법)), 건축법 시행령 · 시행규칙 등(6유형(하위법)), 관련법령ID 포함 |
| `get_term_articles` | `term="임대차", display=5` | ✅ **5건** — 농어촌정비법 제85조(농어촌관광휴양지사업자의 신고 등), 농지법 제23조 · 제24조 · **제24조의2**(임대차 기간) |
| `get_daily_to_legal` | `dailyTerm="월세"` | ✅ 사글세 · 월세집 |
| `get_legal_to_daily` | `legalTerm="임대차"` | ✅ **10건** — 반전세 · 월세 · 임대 · 임대인 · 임대차계약 · 임차 · 임차인 · 전대차 · 전세 · 전월세 |

수정 전에는 네 줄 모두 0건이었습니다.

### 회귀 테스트

`src/tools/knowledge-base.test.ts` 를 새로 추가했습니다(11건). 실측 응답을 축약한 픽스처를 쓰고,
`fetchApi` 호출 인자를 잡아 **엔드포인트 · target · `relType` 부재**를 직접 검증합니다 —
같은 오타가 다시 들어오면 테스트가 깨집니다. 한글 래퍼 파싱, `<검색결과개수>` 를 총건수로 쓰지 않는 것,
가지번호 표기, `display` 절단, 빈 본문에서 예외 없이 `[NOT_FOUND]` 로 끝나는 것도 함께 덮습니다.

### 실행한 검사

```
npm run typecheck    통과
npm test             77 파일 733건 전부 통과 (기존 722 + 신규 11)
npm run build        통과
npm run dead-code    통과 (knip)
npm run verify:package  통과 (272 packed files)
```

## 남은 이슈 (이 PR 범위 밖 — 보고용)

1. **연계 방향 구분이 없습니다.** `get_daily_to_legal` 과 `get_legal_to_daily` 가 이제 같은 `lstrmRlt` 를
   부릅니다. 법제처에는 역방향 전용 target `dlytrmRlt` 가 따로 있습니다(`lstrmRlt` 응답의 `<용어간관계링크>`에
   노출됩니다). 실데이터는 정상적으로 나오지만 방향이 엄밀하지는 않습니다. 보고한 오타 범위 밖이라 손대지 않았습니다.
2. `get_daily_term`(일상용어)이 `lstrm`(법령용어) target 을 씁니다. 일상용어 전용 target 은 `dlytrm` 입니다.
3. `parseKBXML` 의 `_rootTag` 미사용 + 항목 태그 하드코딩 자체가 구조적 취약점으로 보입니다. 이번에는 회귀 위험 때문에
   손대지 않았지만, 별도 이슈로 정리할 가치가 있어 보입니다.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhkqwEfFhpmU5aKnBxc5tN
